### PR TITLE
Ext-Web-Component-ApiDocs-Update: Kitchensink Api Docs examples updated

### DIFF
--- a/api-docs/charts/src/draw/Container.js
+++ b/api-docs/charts/src/draw/Container.js
@@ -7,159 +7,144 @@
  * used as the foundation for all of the chart classes but may also be created directly
  * in order to create custom drawings.
  *
- *      ```HTML
- *      @example({tab: 1})
- *        <ext-container padding="10" layout="fit" fitToParent="true" height="100%">
- *            <ext-panel shadow="true" layout="fit">
- *              <ext-toolbar docked="top">
- *              <ext-container>
+ *@example({tab: 1})
+ *```HTML
+ *<ext-container padding="10" layout="fit" fitToParent="true" height="100%">
+ *    <ext-panel shadow="true" layout="fit">
+ *        <ext-toolbar docked="top">
+ *            <ext-container>
  *                <span>Use your finger or mouse to paint on the surface below.</span>
- *              </ext-container>
- *              <ext-spacer ></ext-spacer>
- *              <ext-button ontap="draw.clear" text="Clear"></ext-button>
- *            </ext-toolbar>
- *            <ext-draw onready="draw.onReady"></ext-draw>
- *          </ext-panel>
- *        </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
- *      import '@sencha/ext-web-components/dist/ext-draw.component';
- *      import '@sencha/ext-web-components/dist/ext-toolbar.component';
- *      import '@sencha/ext-web-components/dist/ext-spacer.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
+ *            </ext-container>
+ *            <ext-spacer ></ext-spacer>
+ *            <ext-button ontap="draw.clear" text="Clear"></ext-button>
+ *        </ext-toolbar>
+ *        <ext-draw onready="draw.onReady"></ext-draw>
+ *    </ext-panel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
+ *import '@sencha/ext-web-components/dist/ext-draw.component';
+ *import '@sencha/ext-web-components/dist/ext-toolbar.component';
+ *import '@sencha/ext-web-components/dist/ext-spacer.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
  *
- *        export default class DrawComponent {
- *            constructor () {}
- *            onReady = (ele) => {
- *                this.drawRef = ele.detail.cmp;
- *                this.drawRef.on({
- *                  element: 'element',
- *                  mousedown: this.onMouseDown.bind(this),
- *                  mousemove: this.onMouseMove.bind(this),
- *                  mouseup: this.onMouseUp.bind(this),
- *                  mouseleave: this.onMouseUp.bind(this)
- *                });
- *             }
+ *export default class DrawComponent {
+ *    constructor () {}
+ *    onReady = (ele) => {
+ *         this.drawRef = ele.detail.cmp;
+ *         this.drawRef.on({
+ *         element: 'element',
+ *         mousedown: this.onMouseDown.bind(this),
+ *         mousemove: this.onMouseMove.bind(this),
+ *         mouseup: this.onMouseUp.bind(this),
+ *         mouseleave: this.onMouseUp.bind(this)
+ *         });
+ *     }
  *
- *             clear = () => {
- *               this.drawRef.getSurface().destroy();
- *               this.drawRef.getSurface('overlay').destroy();
- *               this.drawRef.renderFrame();
- *             }
+ *     clear = () => {
+ *         this.drawRef.getSurface().destroy();
+ *         this.drawRef.getSurface('overlay').destroy();
+ *         this.drawRef.renderFrame();
+ *     }
  *
- *             onMouseDown = (e) => {
- *               let surface = this.drawRef.getSurface(), xy, x, y;
+ *     onMouseDown = (e) => {
+ *         let surface = this.drawRef.getSurface(), xy, x, y;
  *
- *               if (!this.drawRef.sprite) {
- *                 xy = surface.getEventXY(e);
- *                 x = xy[0];
- *                 y = xy[1];
+ *         if (!this.drawRef.sprite) {
+ *             xy = surface.getEventXY(e);
+ *             x = xy[0];
+ *             y = xy[1];
  *
- *                 this.drawRef.list = [x, y, x, y];
- *                 this.drawRef.lastEventX = x;
- *                 this.drawRef.lastEventY = y;
+ *             this.drawRef.list = [x, y, x, y];
+ *             this.drawRef.lastEventX = x;
+ *             this.drawRef.lastEventY = y;
  *
- *                 this.drawRef.sprite = surface.add({
- *                   type: 'path',
- *                   path: [
+ *             this.drawRef.sprite = surface.add({
+ *                 type: 'path',
+ *                 path: [
  *                     'M', this.drawRef.list[0], this.drawRef.list[1], 'L', this.drawRef.list[0] + 1e-1, this.drawRef.list[1] + 1e-1
- *                   ],
- *                   lineWidth: 30 * Math.random() + 10,
- *                     lineCap: 'round',
- *                     lineJoin: 'round',
- *                     strokeStyle: new Ext.util.Color(
- *                       Math.random() * 127 + 128, Math.random() * 127 + 128, Math.random() * 127 + 128
- *                     )
- *                 });
- *               surface.renderFrame();
- *             }
- *            }
+ *                 ],
+ *                 lineWidth: 30 * Math.random() + 10,
+ *                 lineCap: 'round',
+ *                 lineJoin: 'round',
+ *                 strokeStyle: new Ext.util.Color(
+ *                     Math.random() * 127 + 128, Math.random() * 127 + 128, Math.random() * 127 + 128
+ *                 )
+ *             });
+ *             surface.renderFrame();
+ *         }
+ *     }
  *
- *            onMouseMove = (e) => {
- *              let surface = this.drawRef.getSurface(), path, xy, x, y, dx, dy, D;
- *              if (this.drawRef.sprite) {
- *                 xy = surface.getEventXY(e);
- *                 x = xy[0];
- *                 y = xy[1];
- *                 dx = this.drawRef.lastEventX - x;
- *                 dy = this.drawRef.lastEventY - y;
- *                 D = 10;
+ *     onMouseMove = (e) => {
+ *         let surface = this.drawRef.getSurface(), path, xy, x, y, dx, dy, D;
+ *         if (this.drawRef.sprite) {
+ *           xy = surface.getEventXY(e);
+ *           x = xy[0];
+ *           y = xy[1];
+ *           dx = this.drawRef.lastEventX - x;
+ *           dy = this.drawRef.lastEventY - y;
+ *           D = 10;
  *
- *                 if (dx * dx + dy * dy < D * D) {
- *                   this.drawRef.list.length -= 2;
- *                   this.drawRef.list.push(x, y);
- *                 } else {
- *                   this.drawRef.list.length -= 2;
- *                   this.drawRef.list.push(this.drawRef.lastEventX = x, this.drawRef.lastEventY = y);
- *                   this.drawRef.list.push(this.drawRef.lastEventX + 1, this.drawRef.lastEventY + 1);
- *                 }
+ *           if (dx * dx + dy * dy < D * D) {
+ *             this.drawRef.list.length -= 2;
+ *             this.drawRef.list.push(x, y);
+ *           } else {
+ *             this.drawRef.list.length -= 2;
+ *             this.drawRef.list.push(this.drawRef.lastEventX = x, this.drawRef.lastEventY = y);
+ *             this.drawRef.list.push(this.drawRef.lastEventX + 1, this.drawRef.lastEventY + 1);
+ *           }
  *
- *                 path = this.smoothList(this.drawRef.list);
+ *           path = this.smoothList(this.drawRef.list);
  *
- *                 this.drawRef.sprite.setAttributes({
- *                   path: path
- *                 });
+ *           this.drawRef.sprite.setAttributes({
+ *               path: path
+ *           });
  *
- *                 if (Ext.os.is.Android) {
- *                   Ext.this.drawRef.Animator.schedule(() => surface.renderFrame(), this.drawRef);
- *                 } else {
- *                   surface.renderFrame();
- *                 }
- *              }
- *            }
+ *           if (Ext.os.is.Android) {
+ *             Ext.this.drawRef.Animator.schedule(() => surface.renderFrame(), this.drawRef);
+ *           } else {
+ *             surface.renderFrame();
+ *           }
+ *         }
+ *     }
  *
- *            onMouseUp = (e) => {
- *              this.drawRef.sprite = null;
- *            }
+ *     onMouseUp = (e) => {
+ *        this.drawRef.sprite = null;
+ *     }
  *
- *            onResize = () => {
- *               const size = this.drawRef.element.getSize();
- *               this.drawRef.getSurface().setRect([0, 0, size.width, size.height]);
- *               this.drawRef.renderFrame();
- *            }
+ *     onResize = () => {
+ *         const size = this.drawRef.element.getSize();
+ *         this.drawRef.getSurface().setRect([0, 0, size.width, size.height]);
+ *         this.drawRef.renderFrame();
+ *     }
  *
- *            smoothList = (points) => {
- *               if (points.length < 3) {
- *                   return ['M', points[0], points[1]];
- *               }
+ *     smoothList = (points) => {
+ *         if (points.length < 3) {
+ *           return ['M', points[0], points[1]];
+ *         }
  *
- *               var dx = [], dy = [], result = ['M'], i, ln = points.length;
+ *         var dx = [], dy = [], result = ['M'], i, ln = points.length;
  *
- *               for (i = 0; i < ln; i += 2) {
- *                   dx.push(points[i]);
- *                   dy.push(points[i + 1]);
- *             }
+ *         for (i = 0; i < ln; i += 2) {
+ *           dx.push(points[i]);
+ *           dy.push(points[i + 1]);
+ *         }
  *
- *               dx = Ext.draw.Draw.spline(dx);
- *               dy = Ext.draw.Draw.spline(dy);
- *               result.push(dx[0], dy[0], 'C');
+ *         dx = Ext.draw.Draw.spline(dx);
+ *         dy = Ext.draw.Draw.spline(dy);
+ *         result.push(dx[0], dy[0], 'C');
  *
- *               for (i = 1, ln = dx.length; i < ln; i++) {
- *                  result.push(dx[i], dy[i]);
- *               }
+ *         for (i = 1, ln = dx.length; i < ln; i++) {
+ *            result.push(dx[i], dy[i]);
+ *         }
  *
- *               return result;
- *              }
- *          }
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *
- *      export default class SpinnerFieldComponent {}
- *      ```
+ *         return result;
+ *    }
+ *}
+ *```
  */
 
 /**

--- a/api-docs/core/src/Progress.js
+++ b/api-docs/core/src/Progress.js
@@ -12,66 +12,66 @@
  * want to show progress throughout an operation that has predictable points of interest
  * at which you can update the control.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-panel layout='{ "type": "vbox", "align": "center" }'>
- *          <ext-progress
- *            value="0"
- *            text="Loading: 0"
- *            width="75%"
- *            onready="progress.progressBar1Ready"
- *          >
- *            <ext-container
- *              style='{"marginTop": "20"}'
- *              html="<span>Loading: 0%</span>"
- *              onready="progress.innnerContainerReady"
- *            >
- *            </ext-container>
- *          </ext-progress>
- *          <ext-progress
- *            value="0"
- *            width="75%"
- *            onready="progress.progressBar2Ready"
- *          >
- *          </ext-progress>
- *      <ext-panel>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
- *      import '@sencha/ext-web-components/dist/ext-progress.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-panel layout='{ "type": "vbox", "align": "center" }'>
+ *    <ext-progress
+ *      value="0"
+ *      text="Loading: 0"
+ *      width="75%"
+ *      onready="progress.progressBar1Ready"
+ *    >
+ *      <ext-container
+ *        style='{"marginTop": "20"}'
+ *        html="<span>Loading: 0%</span>"
+ *        onready="progress.innnerContainerReady"
+ *      >
+ *      </ext-container>
+ *    </ext-progress>
+ *    <ext-progress
+ *      value="0"
+ *      width="75%"
+ *      onready="progress.progressBar2Ready"
+ *    >
+ *    </ext-progress>
+ *<ext-panel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
+ *import '@sencha/ext-web-components/dist/ext-progress.component';
  *
- *      export default class ProgressComponent {
- *        constructor() {
- *          this.progress = 0;
- *        }
+ *export default class ProgressComponent {
+ *  constructor() {
+ *    this.progress = 0;
+ *  }
  *
- *        progressBar1Ready = (event) => {
- *          this.progressBar1Cmp = event.detail.cmp;
- *        }
+ *  progressBar1Ready = (event) => {
+ *    this.progressBar1Cmp = event.detail.cmp;
+ *  }
  *
- *        progressBar2Ready = (event) => {
- *          this.progressBar2Cmp = event.detail.cmp;
+ *  progressBar2Ready = (event) => {
+ *    this.progressBar2Cmp = event.detail.cmp;
  *
- *          setInterval(() => {
- *            this.progress += 1;
+ *    setInterval(() => {
+ *      this.progress += 1;
  *
- *            if (this.progress > 100) {
- *              this.progress = 0;
- *            }
- *
- *            this.progressBar1Cmp.setValue(this.progress);
- *            this.progressBar1Cmp.setText(`Loading: ${this.progress}`);
- *            this.innnerContainerCmp.setHtml(`Loading: ${this.progress}`);
- *            this.progressBar2Cmp.setValue(this.progress);
- *          }, 100);
- *        }
- *
- *        innnerContainerReady = (event) => {
- *          this.innnerContainerCmp = event.detail.cmp;
- *        }
+ *      if (this.progress > 100) {
+ *        this.progress = 0;
  *      }
- *      ```
+ *
+ *      this.progressBar1Cmp.setValue(this.progress);
+ *      this.progressBar1Cmp.setText(`Loading: ${this.progress}`);
+ *      this.innnerContainerCmp.setHtml(`Loading: ${this.progress}`);
+ *      this.progressBar2Cmp.setValue(this.progress);
+ *    }, 100);
+ *  }
+ *
+ *  innnerContainerReady = (event) => {
+ *    this.innnerContainerCmp = event.detail.cmp;
+ *  }
+ *}
+ *```
  */
 
 /**

--- a/api-docs/core/src/list/Tree.js
+++ b/api-docs/core/src/list/Tree.js
@@ -7,60 +7,60 @@
  *
  * Simple Treelist using inline data:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-panel shadow="true" layout="fit">
- *          <ext-treelist
- *              ref="tree"
- *              onready="treelist.onTreeListReady"
- *              store={this.store}
- *          >
- *          </ext-treelist>
- *      </ext-panel>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-treelist.component';
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-panel shadow="true" layout="fit">
+ *    <ext-treelist
+ *        ref="tree"
+ *        onready="treelist.onTreeListReady"
+ *        store={this.store}
+ *    >
+ *    </ext-treelist>
+ *</ext-panel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-treelist.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
  *
- *      export default class TreeListComponent {
- *          constructor() {
- *              this.store = Ext.create('Ext.data.TreeStore', {
- *                rootVisible: true,
- *                root: {
- *                    expanded: true,
- *                    children: [{
- *                      text: 'detention',
- *                      leaf: true,
- *                      iconCls: 'x-fa fa-frown-o'
- *                    }, {
- *                      text: 'homework',
- *                      expanded: true,
- *                      iconCls: 'x-fa fa-folder',
- *                      children: [{
- *                         text: 'book report',
- *                         leaf: true,
- *                         iconCls: 'x-fa fa-book'
- *                      }, {
- *                         text: 'algebra',
- *                         leaf: true,
- *                         iconCls: 'x-fa fa-graduation-cap'
- *                      }]
- *                    }, {
- *                      text: 'buy lottery tickets',
- *                      leaf: true,
- *                      iconCls: 'x-fa fa-usd'
- *                    }]
- *                 }
- *             });
- *         }
+ *export default class TreeListComponent {
+ *    constructor() {
+ *        this.store = Ext.create('Ext.data.TreeStore', {
+ *          rootVisible: true,
+ *          root: {
+ *              expanded: true,
+ *              children: [{
+ *                text: 'detention',
+ *                leaf: true,
+ *                iconCls: 'x-fa fa-frown-o'
+ *              }, {
+ *                text: 'homework',
+ *                expanded: true,
+ *                iconCls: 'x-fa fa-folder',
+ *                children: [{
+ *                   text: 'book report',
+ *                   leaf: true,
+ *                   iconCls: 'x-fa fa-book'
+ *                }, {
+ *                   text: 'algebra',
+ *                   leaf: true,
+ *                   iconCls: 'x-fa fa-graduation-cap'
+ *                }]
+ *              }, {
+ *                text: 'buy lottery tickets',
+ *                leaf: true,
+ *                iconCls: 'x-fa fa-usd'
+ *              }]
+ *           }
+ *       });
+ *   }
  *
- *         onTreeListReady(event) {
- *              this.treeListCmp = event.detail.cmp;
- *              this.treeListCmp.setStore(this.store);
- *         }
- *      }
- *      ```
+ *   onTreeListReady(event) {
+ *        this.treeListCmp = event.detail.cmp;
+ *        this.treeListCmp.setStore(this.store);
+ *   }
+ *}
+ *```
  *
  * To collapse the Treelist for use in a smaller navigation view see {@link #micro}.
  * Parent Treelist node expansion may be refined using the {@link #singleExpand} and

--- a/api-docs/modern/modern/src/ActionSheet.js
+++ b/api-docs/modern/modern/src/ActionSheet.js
@@ -5,24 +5,24 @@
  *
  * ActionSheet is a `Sheet` that is docked at the bottom of the screen by default.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-actionsheet displayed="true">
- *              <ext-button ui="decline" text="Delete Draft"></ext-button>
- *              <ext-button text="Save Draft"></ext-button>
- *              <ext-button text="Cancel"></ext-button>
- *          <ext-actionsheet>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-actionsheet.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-actionsheet displayed="true">
+ *        <ext-button ui="decline" text="Delete Draft"></ext-button>
+ *        <ext-button text="Save Draft"></ext-button>
+ *        <ext-button text="Cancel"></ext-button>
+ *    <ext-actionsheet>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-actionsheet.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
  *
- *      export default class ActionSheetComponent {}
- *      ```
+ *export default class ActionSheetComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/Button.js
+++ b/api-docs/modern/modern/src/Button.js
@@ -9,41 +9,41 @@
  *
  * Here is an example showing multiple button presentations.
  *
- * ```HTML
- * @example({tab: 1})
- * <ext-container padding="10">
- *     <ext-button 
- *         text="Say Hello" 
- *         handler="button.sayHello"
- *         ui="action raised" 
- *     >
- *     <ext-button>
- *     <ext-button 
- *         text="Say Goodbye" 
- *         handler="button.sayGoodbye"
- *         ui="action raised" 
- *     >
- *     <ext-button>
- *     <ext-container onready="button.resultContainerReady"></ext-container>
- * </ext-container>
- * ```
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container padding="10">
+ *    <ext-button 
+ *        text="Say Hello" 
+ *        handler="button.sayHello"
+ *        ui="action raised" 
+ *    >
+ *    <ext-button>
+ *    <ext-button 
+ *        text="Say Goodbye" 
+ *        handler="button.sayGoodbye"
+ *        ui="action raised" 
+ *    >
+ *    <ext-button>
+ *    <ext-container onready="button.resultContainerReady"></ext-container>
+ *</ext-container>
+ *```
  *
- * ```javascript
- * @example({tab: 2, packages: ['ext-web-components']})
- * import '@sencha/ext-web-components/dist/ext-button.component';
- * import '@sencha/ext-web-components/dist/ext-container.component'
- * export default class ButtonComponent {
- *     resultContainerReady(event) {
- *         this.resultContainer = event.detail.cmp;
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-container.component'
+ *export default class ButtonComponent {
+ *    resultContainerReady(event) {
+ *        this.resultContainer = event.detail.cmp;
  *     
- *     sayHello = () => {
- *         this.resultContainer.setHtml('Hello world!');
+ *    sayHello = () => {
+ *        this.resultContainer.setHtml('Hello world!');
  *     
- *     sayGoodbye = () => {
- *         this.resultContainer.setHtml('Goodbye cruel world.');
- *     }
- * }
- * ```
+ *    sayGoodbye = () => {
+ *        this.resultContainer.setHtml('Goodbye cruel world.');
+ *    }
+ *}
+ *```
  *
  * ## Icons
  *

--- a/api-docs/modern/modern/src/Dialog.js
+++ b/api-docs/modern/modern/src/Dialog.js
@@ -9,73 +9,73 @@
  * popup windows, but provide similar modal experiences.
  *
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-button
- *              text="Show Dialog"
- *              handler="dialogpopup.showDialog"
- *              ui="action raised"
- *          >
- *          </ext-button>
- *          <ext-dialog
- *              displayed="false"
- *              title="Dialog"
- *              closable="true"
- *              maximizable="true"
- *              closeAction="hide"
- *              maskTapHandler="dialogpopup.onCancel"
- *              bodyPadding="20"
- *              maxWidth="200"
- *              defaultFocus="#ok"
- *              onHide="dialogpopup.onHide"
- *              onready="dialogpopup.dialogReady"
- *           >
- *                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
- *                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
- *                commodo consequat.'
- *               <ext-button
- *                   text="Cancel"
- *                   handler="dialogpopup.onCancel"
- *               >
- *               </ext-button>
- *               <ext-button
- *                   itemId="ok"
- *                   text="OK"
- *                  handler="dialogpopup.onOk"
- *               >
- *               </ext-button>
- *          </ext-dialog>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-dialog.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-button
+ *        text="Show Dialog"
+ *        handler="dialogpopup.showDialog"
+ *        ui="action raised"
+ *    >
+ *    </ext-button>
+ *    <ext-dialog
+ *        displayed="false"
+ *        title="Dialog"
+ *        closable="true"
+ *        maximizable="true"
+ *        closeAction="hide"
+ *        maskTapHandler="dialogpopup.onCancel"
+ *        bodyPadding="20"
+ *        maxWidth="200"
+ *        defaultFocus="#ok"
+ *        onHide="dialogpopup.onHide"
+ *        onready="dialogpopup.dialogReady"
+ *     >
+ *          Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore
+ *          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+ *          commodo consequat.'
+ *         <ext-button
+ *             text="Cancel"
+ *             handler="dialogpopup.onCancel"
+ *         >
+ *         </ext-button>
+ *         <ext-button
+ *             itemId="ok"
+ *             text="OK"
+ *             handler="dialogpopup.onOk"
+ *         >
+ *         </ext-button>
+ *    </ext-dialog>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-dialog.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
  * 
- *      export default class DialogPopupComponent {
- *        dialogReady = (event) => {
- *            this.dialog = event.detail.cmp
- *        }
+ *export default class DialogPopupComponent {
+ *  dialogReady = (event) => {
+ *      this.dialog = event.detail.cmp
+ *  }
  * 
- *        showDialog = () => {
- *            this.dialog.setDisplayed(true);
- *        }
+ *  showDialog = () => {
+ *      this.dialog.setDisplayed(true);
+ *  }
  *
- *        onOk = () => {
- *            this.dialog.setDisplayed(false);
- *        }
+ *  onOk = () => {
+ *      this.dialog.setDisplayed(false);
+ *  }
  *
- *        onCancel = () => {
- *            this.dialog.setDisplayed(false);
- *        }
+ *  onCancel = () => {
+ *      this.dialog.setDisplayed(false);
+ *  }
  *
- *        onHide = () => {
- *            this.dialog.setDisplayed(false);
- *        }
- *      }
- *      ```
+ *  onHide = () => {
+ *      this.dialog.setDisplayed(false);
+ *  }
+ *}
+ *```
  * 
  *
  * ## Buttons

--- a/api-docs/modern/modern/src/Img.js
+++ b/api-docs/modern/modern/src/Img.js
@@ -8,24 +8,24 @@
  * like any other component. This component typically takes between 1 and 3 props - a {@link #src}, and
  * optionally a {@link #height} and a {@link #width}:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-panel shadow="true" layout="fit">
- *          <ext-image
- *              width="64"
- *              height="64"
- *              src="http://www.sencha.com/assets/images/sencha-avatar-64x64.png"
- *          >
- *          </ext-image>
- *      </ext-panel>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
- *      import '@sencha/ext-web-components/dist/ext-image.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-panel shadow="true" layout="fit">
+ *    <ext-image
+ *        width="64"
+ *        height="64"
+ *        src="http://www.sencha.com/assets/images/sencha-avatar-64x64.png"
+ *    >
+ *    </ext-image>
+ *</ext-panel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
+ *import '@sencha/ext-web-components/dist/ext-image.component';
  *
- *      export default class ImageFieldComponent {}
- *      ``
+ *export default class ImageFieldComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/MessageBox.js
+++ b/api-docs/modern/modern/src/MessageBox.js
@@ -248,41 +248,41 @@
  *
  * ## Examples
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-panel shadow layout='{"type": "vbox", "align": "stretch"}'>
- *          <ext-button handler="messagebox.alertBoxHandler" text="Alert"/>
- *          <ext-button handler="messagebox.promptHandler" text="Prompt"/>
- *          <ext-button handler="messagebox.confirmHandler" text="Confirm"/>
- *      </ext-panel>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-panel shadow layout='{"type": "vbox", "align": "stretch"}'>
+ *    <ext-button handler="messagebox.alertBoxHandler" text="Alert"/>
+ *    <ext-button handler="messagebox.promptHandler" text="Prompt"/>
+ *    <ext-button handler="messagebox.confirmHandler" text="Confirm"/>
+ *</ext-panel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
  *      
- *      Ext.require('Ext.MessageBox');
+ *Ext.require('Ext.MessageBox');
  * 
- *      export default class MessageBoxComponent {
- *          alertBoxHandler = () => {
- *              Ext.Msg.alert('Title', 'The quick brown fox jumped over the lazy dog.');
- *          }
+ *export default class MessageBoxComponent {
+ *    alertBoxHandler = () => {
+ *        Ext.Msg.alert('Title', 'The quick brown fox jumped over the lazy dog.');
+ *    }
  *
- *          promptHandler = () => {
- *             Ext.Msg.prompt('Welcome!', 'What\'s your first name?', this.onPromptResult.bind(this));
- *          }
+ *    promptHandler = () => {
+ *       Ext.Msg.prompt('Welcome!', 'What\'s your first name?', this.onPromptResult.bind(this));
+ *    }
  * 
- *          confirmHandler = () => {
- *             Ext.Msg.confirm('Confirmation', 'Are you sure you want to do that?', this.onConfirmResult.bind(this));
- *          }
+ *    confirmHandler = () => {
+ *       Ext.Msg.confirm('Confirmation', 'Are you sure you want to do that?', this.onConfirmResult.bind(this));
+ *    }
  * 
- *          onConfirmResult = (buttonId, value, opt) => {
- *              Ext.toast(`User clicked ${buttonId} button.`);
- *          }
+ *    onConfirmResult = (buttonId, value, opt) => {
+ *        Ext.toast(`User clicked ${buttonId} button.`);
+ *    }
  *
- *          onPromptResult = (buttonId, value) => {
- *             Ext.toast(`User clicked ${buttonId} and entered value "${value}".`);
- *          }
- *      }
- *      ```
+ *    onPromptResult = (buttonId, value) => {
+ *       Ext.toast(`User clicked ${buttonId} and entered value "${value}".`);
+ *    }
+ *}
+ *```
  */

--- a/api-docs/modern/modern/src/Panel.js
+++ b/api-docs/modern/modern/src/Panel.js
@@ -19,63 +19,63 @@
  * If configured with `{@link #cfg-anchor: true}`, when you {@link #showBy} another
  * component, there will be an anchor arrow pointing to the reference component.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-panel
- *              shadow
- *              title="Panel"
- *              height={300}
- *              width={500}
- *              tools='{[
- *                  { "type": "minimize", "handler": "toolHandler" },
- *                  { "type": "refresh, "handler": "toolHandler" },
- *                  { "type": "save", "handler": "toolHandler" },
- *                  { "type": "search", "handler": "toolHandler" },
- *                  { "type": "close", "handler": "toolHandler" }
- *              ]}'
- *          >
- *              <p>Panel Body</p>
- *          </ext-panel>
- *          <ext-button ui="action" handler={() => this.refs.modal.show()} margin="20 0 0 0" text="Show Modal"/>
- *          <ext-panel
- *              ref="modal"
- *              title="Floated Panel"
- *              modal
- *              floated
- *              centered
- *              hideOnMaskTap
- *              width={Ext.filterPlatform('ie10') ? '100%' : (Ext.os.deviceType == 'Phone') ? 260 : 400}
- *              maxHeight={Ext.filterPlatform('ie10') ? '30%' : (Ext.os.deviceType == 'Phone') ? 220 : 400}
- *              showAnimation='{{
- *                   "type": "popIn",
- *                   "duration": 250,
- *                   "easing": "ease-out"
- *              }}'
- *              hideAnimation='{{
- *                   "type": "popOut",
- *                   "duration": 250,
- *                   "easing": "ease-out"
- *              }}'
- *          >
- *              <p>This is a modal, centered and floated panel. hideOnMaskTap is true by default so we can tap anywhere outside the overlay to hide it.</p>
- *          </ext-panel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-panel
+ *        shadow
+ *        title="Panel"
+ *        height={300}
+ *        width={500}
+ *        tools='{[
+ *            { "type": "minimize", "handler": "toolHandler" },
+ *            { "type": "refresh, "handler": "toolHandler" },
+ *            { "type": "save", "handler": "toolHandler" },
+ *            { "type": "search", "handler": "toolHandler" },
+ *            { "type": "close", "handler": "toolHandler" }
+ *        ]}'
+ *    >
+ *        <p>Panel Body</p>
+ *    </ext-panel>
+ *    <ext-button ui="action" handler={() => this.refs.modal.show()} margin="20 0 0 0" text="Show Modal"/>
+ *    <ext-panel
+ *        ref="modal"
+ *        title="Floated Panel"
+ *        modal
+ *        floated
+ *        centered
+ *        hideOnMaskTap
+ *        width={Ext.filterPlatform('ie10') ? '100%' : (Ext.os.deviceType == 'Phone') ? 260 : 400}
+ *        maxHeight={Ext.filterPlatform('ie10') ? '30%' : (Ext.os.deviceType == 'Phone') ? 220 : 400}
+ *        showAnimation='{{
+ *             "type": "popIn",
+ *             "duration": 250,
+ *             "easing": "ease-out"
+ *        }}'
+ *        hideAnimation='{{
+ *             "type": "popOut",
+ *             "duration": 250,
+ *             "easing": "ease-out"
+ *        }}'
+ *    >
+ *        <p>This is a modal, centered and floated panel. hideOnMaskTap is true by default so we can tap anywhere outside the overlay to hide it.</p>
+ *    </ext-panel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
  * 
- *      Ext.require('Ext.Toast');
+ *Ext.require('Ext.Toast');
  * 
- *      export default class PanelComponent {
- *         toolHandler = (owner, tool) => {
- *            Ext.toast(`You clicked ${tool.config.type}`);
- *         }
- *      }
- *      ```
+ *export default class PanelComponent {
+ *   toolHandler = (owner, tool) => {
+ *      Ext.toast(`You clicked ${tool.config.type}`);
+ *   }
+ *}
+ *```
  *
  *     import '@sencha/ext-web-components/dist/ext-container.component';
  *     import '@sencha/ext-web-components/dist/ext-button.component';

--- a/api-docs/modern/modern/src/SegmentedButton.js
+++ b/api-docs/modern/modern/src/SegmentedButton.js
@@ -7,37 +7,37 @@
  * a child of a {@link Ext.Toolbar} and would be used to switch between different views.
  *
  * ## Example usage:
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-toolbar>
- *              <div style="margin-right: 10px;">Default UI:</div>
- *              <ext-segmentedbutton>
- *                             <ext-button pressed text="Low"></ext-button>
- *                             <ext-button text="Medium"></ext-button>
- *                             <ext-button text="High"></ext-button>
- *              </ext-segmentedbutton>
-*           </ext-toolbar>
- *              <ext-toolbar margin="0 0 20 0">
- *                  <div style="margin-right: 10px;">Toolbar UI:</div>
- *                      <ext-segmentedbutton>
- *                             <ext-button ui="default-toolbar" pressed text="Low"></ext-button>
- *                             <ext-button ui="default-toolbar" text="Medium"></ext-button>
- *                             <ext-button ui="default-toolbar" text="High"></ext-button>
- *                      </ext-segmentedbutton>
- *              </ext-toolbar>
- *      </ext-container>
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-toolbar>
+ *        <div style="margin-right: 10px;">Default UI:</div>
+ *        <ext-segmentedbutton>
+ *            <ext-button pressed text="Low"></ext-button>
+ *            <ext-button text="Medium"></ext-button>
+ *            <ext-button text="High"></ext-button>
+ *        </ext-segmentedbutton>
+*     </ext-toolbar>
+ *    <ext-toolbar margin="0 0 20 0">
+ *        <div style="margin-right: 10px;">Toolbar UI:</div>
+ *        <ext-segmentedbutton>
+ *            <ext-button ui="default-toolbar" pressed text="Low"></ext-button>
+ *            <ext-button ui="default-toolbar" text="Medium"></ext-button>
+ *            <ext-button ui="default-toolbar" text="High"></ext-button>
+ *        </ext-segmentedbutton>
+ *    </ext-toolbar>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
  *
- *     import '@sencha/ext-web-components/dist/ext-container.component';
- *     import '@sencha/ext-web-components/dist/ext-toolbar.component';
- *     import '@sencha/ext-web-components/dist/ext-segmentedbutton.component';
- *     import '@sencha/ext-web-components/dist/ext-button.component'; 
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-toolbar.component';
+ *import '@sencha/ext-web-components/dist/ext-segmentedbutton.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component'; 
  * 
- *     export default class SegmentedButtonComponent {}
- *     ```
+ *export default class SegmentedButtonComponent {}
+ *```
  */
 /**
  * @cfg {Boolean} [allowMultiple=false]

--- a/api-docs/modern/modern/src/SplitButton.js
+++ b/api-docs/modern/modern/src/SplitButton.js
@@ -8,42 +8,42 @@
  * primary button action, but any custom handler can provide the arrowclick implementation.
  *
  * ## Example usage:
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-container padding="10" layout="vbox">
- *          <ext-splitbutton 
- *              text="SplitButton" 
- *              ontap="splitbutton.sayHello" 
- *              ui="action alt" 
- *              iconCls="x-fa fa-heart" 
- *              margin="10"
- *           >
- *           </ext-splitbutton>
- *      </ext-container>
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container padding="10" layout="vbox">
+ *    <ext-splitbutton 
+ *         text="SplitButton" 
+ *         ontap="splitbutton.sayHello" 
+ *         ui="action alt" 
+ *         iconCls="x-fa fa-heart" 
+ *         margin="10"
+ *     >
+ *     </ext-splitbutton>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
  *
- *     import '@sencha/ext-web-components/dist/ext-container.component';
- *     import '@sencha/ext-web-components/dist/ext-splitbutton.component';
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-splitbutton.component';
  * 
- *     export default class SplitButtonComponent {
- *          splitButtonReady = (event) => {
- *              const splitButtonCmp = event.detail.cmp;
- *              splitButtonCmp.setMenu([{
- *                  text: "Menu Item 1",
- *                   handler: () => { alert("Item 1 clicked"); }  
- *              }, {
- *                  text: "Menu Item 2",
- *                  handler: () => {alert("Item 2 clicked"); }
- *              }]);  
- *          }
- * 
- *          sayHello = () => {
- *              alert("Hello! The button was clicked");
- *          }
+ *export default class SplitButtonComponent {
+ *     splitButtonReady = (event) => {
+ *         const splitButtonCmp = event.detail.cmp;
+ *         splitButtonCmp.setMenu([{
+ *             text: "Menu Item 1",
+ *             handler: () => { alert("Item 1 clicked"); }  
+ *         }, {
+ *             text: "Menu Item 2",
+ *             handler: () => {alert("Item 2 clicked"); }
+ *         }]);  
  *     }
- *     ```
+ * 
+ *     sayHello = () => {
+ *         alert("Hello! The button was clicked");
+ *     }
+ *}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/TitleBar.js
+++ b/api-docs/modern/modern/src/TitleBar.js
@@ -10,27 +10,27 @@
  *
  * You can also give items of a {@link Ext.TitleBar} an `align` prop of `left` or `right`,
  * which will dock them to the `left` or `right` of the bar.
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-titlebar title="App Title" docked="top">
- *              <ext-button align="left" iconCls="x-fa fa-bars"></ext-button>
- *              <ext-button align="right" iconCls="x-fa fa-inbox" text="Inbox"></ext-button>
- *              <ext-button align="right" iconCls="x-fa fa-user" text="Profile"></ext-button>
- *          </ext-titlebar>
- *       </ext-container>
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-titlebar title="App Title" docked="top">
+ *        <ext-button align="left" iconCls="x-fa fa-bars"></ext-button>
+ *        <ext-button align="right" iconCls="x-fa fa-inbox" text="Inbox"></ext-button>
+ *        <ext-button align="right" iconCls="x-fa fa-user" text="Profile"></ext-button>
+ *    </ext-titlebar>
+ *</ext-container>
  *      
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
  *
- *     import '@sencha/ext-web-components/dist/ext-button.component';
- *     import '@sencha/ext-web-components/dist/ext-container.component';
- *     import '@sencha/ext-web-components/dist/ext-titlebar.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-titlebar.component';
  * 
- *     export default class TitleBarComponent {}
+ *export default class TitleBarComponent {}
  *   
- *     ```
+ *```
  *
 /**
  * @cfg cls

--- a/api-docs/modern/modern/src/Toast.js
+++ b/api-docs/modern/modern/src/Toast.js
@@ -9,31 +9,31 @@
  *
  * This will create one reusable toast container and content will be swapped out as
  * toast messages are queued or displayed.
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-container layout='{"type": "vbox", "align": "left"}'>
- *                         <ext-button
- *                             ui="action"
- *                             ontap="toast.onTap"
- *                             text="Show Toast"
- *                         />
- *                     </ext-container>
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout='{"type": "vbox", "align": "left"}'>
+ *    <ext-button
+ *         ui="action"
+ *         ontap="toast.onTap"
+ *         text="Show Toast"
+ *    />
+ *</ext-container>
  *      
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
  *
- *     import '@sencha/ext-web-components/dist/ext-button.component';
- *     import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-container.component';
  * 
- *     Ext.require('Ext.Toast');
+ *Ext.require('Ext.Toast');
  * 
- *     export default class ToastComponent {
- *       onTap = () => {
- *          Ext.toast('Hello World!')
- *        }
- *      }
- *     ```
+ *export default class ToastComponent {
+ *  onTap = () => {
+ *     Ext.toast('Hello World!')
+ *   }
+ *}
+ *```
  
  */
 

--- a/api-docs/modern/modern/src/Toolbar.js
+++ b/api-docs/modern/modern/src/Toolbar.js
@@ -16,35 +16,35 @@
  *
  * ## Example
  *
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-panel shadow bodyPadding=0>
- *          <ext-toolbar docked="top">
- *              <ext-button text="Default" badgeText="2">
- *              </ext-button>
- *              <ext-spacer>
- *                  <ext-segmentedbutton>
- *                      <ext-button text="Option 1" pressed></ext-button>
- *                       <ext-button text="Option 2"></ext-button>
- *                  </ext-segmentedbutton>
- *              </ext-spacer>
- *              <ext-button ui="action" text="Action">
- *              </ext-button>
- *          </ext-toolbar>
- *          Some Text!
- *      </ext-panel>
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
+ *```HTML
+ *@example({tab: 1})
+ *<ext-panel shadow bodyPadding=0>
+ *    <ext-toolbar docked="top">
+ *        <ext-button text="Default" badgeText="2">
+ *        </ext-button>
+ *        <ext-spacer>
+ *            <ext-segmentedbutton>
+ *                <ext-button text="Option 1" pressed></ext-button>
+ *                <ext-button text="Option 2"></ext-button>
+ *            </ext-segmentedbutton>
+ *        </ext-spacer>
+ *        <ext-button ui="action" text="Action">
+ *        </ext-button>
+ *    </ext-toolbar>
+ *    Some Text!
+ *</ext-panel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
  *
- *     import '@sencha/ext-web-components/dist/ext-toolbar.component';
- *     import '@sencha/ext-web-components/dist/ext-button.component';
- *     import '@sencha/ext-web-components/dist/ext-spacer.component';
- *     import '@sencha/ext-web-components/dist/ext-segmentedbutton.component';
- *     import '@sencha/ext-web-components/dist/ext-panel.component';
+ *import '@sencha/ext-web-components/dist/ext-toolbar.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-spacer.component';
+ *import '@sencha/ext-web-components/dist/ext-segmentedbutton.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
  * 
- *     export default class ToolbarComponent {}
- *     ```
+ *export default class ToolbarComponent {}
+ *```
  */
 /**
  * @cfg {String/Ext.Title} [title=null]

--- a/api-docs/modern/modern/src/carousel/Carousel.js
+++ b/api-docs/modern/modern/src/carousel/Carousel.js
@@ -9,27 +9,27 @@
  * Carousels can be oriented either horizontally or vertically and are easy to configure - they just work like any other
  * Container.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="fit">
- *          <ext-carousel>
- *              <ext-container html="<div>Slide 1!</div>">
- *              </ext-container>
- *              <ext-container html="<div>Slide 2!</div>">
- *              </ext-container>
- *              <ext-container html="<div>Slide 3!</div>">
- *              </ext-container>
- *          <ext-carousel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-carousel.component';
- *      import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="fit">
+ *    <ext-carousel>
+ *        <ext-container html="<div>Slide 1!</div>">
+ *        </ext-container>
+ *        <ext-container html="<div>Slide 2!</div>">
+ *        </ext-container>
+ *        <ext-container html="<div>Slide 3!</div>">
+ *        </ext-container>
+ *    <ext-carousel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-carousel.component';
+ *import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
  *
- *      export default class CarouselComponent {}
- *      ```
+ *export default class CarouselComponent {}
+ *```
  *
  * ### Common Props
  * * {@link #ui} defines the style of the carousel

--- a/api-docs/modern/modern/src/dataview/DataView.js
+++ b/api-docs/modern/modern/src/dataview/DataView.js
@@ -17,34 +17,34 @@
  *
  * At its simplest, a DataView is just a Store full of data and a simple template that we
  * use to render each item:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-dataview
- *              itemTpl="{name} is {age} years old"
- *              onready="dataview.onDataViewready"
- *          >
- *          </ext-dataview>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-dataview.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-dataview
+ *        itemTpl="{name} is {age} years old"
+ *        onready="dataview.onDataViewready"
+ *    >
+ *    </ext-dataview>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-dataview.component';
  *
- *      export default class DataViewComponent {
- *        onDataViewready(event) {
- *          this.dataViewCmp = event.detail.cmp;
- *          this.dataViewCmp.setStore(new Ext.data.Store({
- *             data: [
- *                  {name: 'Peter', age: 26},
- *                  {name: 'Ray', age: 21},
- *                  {name: 'Egon', age: 29},
- *                  {name: 'Winston', age: 24},
- *             ]
- *           }));
- *        }
- *      }
- *      ```
+ *export default class DataViewComponent {
+ *  onDataViewready(event) {
+ *    this.dataViewCmp = event.detail.cmp;
+ *    this.dataViewCmp.setStore(new Ext.data.Store({
+ *       data: [
+ *            {name: 'Peter', age: 26},
+ *            {name: 'Ray', age: 21},
+ *            {name: 'Egon', age: 29},
+ *            {name: 'Winston', age: 24},
+ *       ]
+ *     }));
+ *  }
+ *}
+ *```
  *
  * Here we just defined everything inline so it's all local with nothing being loaded from a server. For each of the
  * data items defined in our Store, DataView will render a {@link Ext.Component Component} and pass in the name and age
@@ -81,37 +81,37 @@
  * render the cover image and title. To do this all we have to do is grab an api key from
  * rotten tomatoes (http://developer.rottentomatoes.com/) and modify the {@link #store}
  * and {@link #itemTpl} a little:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-dataview
- *              itemTpl='<h2>{collectionName}</h2><p><img src={artworkUrl100}></img></p>'
- *              onready="dataview.onDataViewready"
- *          >
- *          </ext-dataview>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-dataview.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-dataview
+ *        itemTpl='<h2>{collectionName}</h2><p><img src={artworkUrl100}></img></p>'
+ *        onready="dataview.onDataViewready"
+ *    >
+ *    </ext-dataview>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-dataview.component';
  *
- *      export default class DataViewComponent {
- *        onDataViewready(event) {
- *          this.dataViewCmp = event.detail.cmp;
- *          this.dataViewCmp.setStore(new Ext.data.Store({
- *              autoLoad: true,
- *              proxy: {
- *                  type: 'jsonp',
- *                  url: 'https://itunes.apple.com/search?term=Pink+Floyd&entity=album',
- *                  reader: {
- *                      type: 'json',
- *                      rootProperty: 'results'
- *                 }
- *              }
- *         }));
- *       }
- *      }
- *      ```
+ *export default class DataViewComponent {
+ *  onDataViewready(event) {
+ *    this.dataViewCmp = event.detail.cmp;
+ *    this.dataViewCmp.setStore(new Ext.data.Store({
+ *        autoLoad: true,
+ *        proxy: {
+ *            type: 'jsonp',
+ *            url: 'https://itunes.apple.com/search?term=Pink+Floyd&entity=album',
+ *            reader: {
+ *                type: 'json',
+ *                rootProperty: 'results'
+ *           }
+ *        }
+ *   }));
+ * }
+ *}
+ *```
  *
  * The Store no longer has hard coded data, instead we've provided a {@link Ext.data.proxy.Proxy Proxy}, which fetches
  * the data for us. In this case we used a JSON-P proxy.

--- a/api-docs/modern/modern/src/dataview/IndexBar.js
+++ b/api-docs/modern/modern/src/dataview/IndexBar.js
@@ -9,61 +9,61 @@
  *
  * Here is an example of the usage in a {@link Ext.List}:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-list
- *          onready="indexbar.readyIndexBarView"
- *          indexBar="true"
- *      >
- *      </ext-list>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-list
+ *    onready="indexbar.readyIndexBarView"
+ *    indexBar="true"
+ *>
+ *</ext-list>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
  * 
- *      export default class IndexBarComponent {
- *          constructor() {
- *              this.store = new Ext.data.Store({
- *                  data: [{
- *                      firstName: 'Screech',
- *                      lastName: 'Powers'
- *                  },
- *                  {
- *                      firstName: 'Kelly',
- *                      lastName: 'Kapowski'
- *                  },
- *                  {
- *                      firstName: 'Zach',
- *                      lastName: 'Morris'
- *                  },
- *                  {
- *                      firstName: 'Jessie',
- *                      lastName: 'Spano'
- *                  },
- *                  {
- *                      firstName: 'Lisa',
- *                      lastName: 'Turtle'
- *                  },
- *                  {
- *                      firstName: 'A.C.',
- *                      lastName: 'Slater'
- *                  },
- *                  {
- *                      firstName: 'Richard',
- *                      lastName: 'Belding'
- *                  }]
- *              })
- *          }
+ *export default class IndexBarComponent {
+ *    constructor() {
+ *        this.store = new Ext.data.Store({
+ *            data: [{
+ *                firstName: 'Screech',
+ *                lastName: 'Powers'
+ *            },
+ *            {
+ *                firstName: 'Kelly',
+ *                lastName: 'Kapowski'
+ *            },
+ *            {
+ *                firstName: 'Zach',
+ *                lastName: 'Morris'
+ *            },
+ *            {
+ *                firstName: 'Jessie',
+ *                lastName: 'Spano'
+ *            },
+ *            {
+ *                firstName: 'Lisa',
+ *                lastName: 'Turtle'
+ *            },
+ *            {
+ *                firstName: 'A.C.',
+ *                lastName: 'Slater'
+ *            },
+ *            {
+ *                firstName: 'Richard',
+ *                lastName: 'Belding'
+ *            }]
+ *        })
+ *    }
  *          
- *          readyIndexBarView(event) {
- *              this.indexBarView = event.detail.cmp;
- *              this.indexBarView.setStore(this.store);
- *              this.indexBarView.setItemTpl(`<div class='contact'>{firstName} <strong>{lastName}</strong></div>`);
- *          }
- *      }
- *      ```
+ *    readyIndexBarView(event) {
+ *        this.indexBarView = event.detail.cmp;
+ *        this.indexBarView.setStore(this.store);
+ *        this.indexBarView.setItemTpl(`<div class='contact'>{firstName} <strong>{lastName}</strong></div>`);
+ *    }
+ *}
+ *```
  * 
  */
 

--- a/api-docs/modern/modern/src/dataview/List.js
+++ b/api-docs/modern/modern/src/dataview/List.js
@@ -4,139 +4,139 @@
  * @xtype list
  *
  * List is a custom styled DataView which allows Grouping, Indexing, Icons, and a Disclosure.
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-list
- *          onready="basiclist.readylistView"
- *      >
- *      </ext-list>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-list.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-list
+ *    onready="basiclist.readylistView"
+ *>
+ *</ext-list>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-list.component';
  * 
- *      export default class BasicListComponent {
- *          constructor() {
- *              this.store = new Ext.data.Store({
- *                  data: [
- *                     {title: 'Item 1'},
- *                     {title: 'Item 2'},
- *                     {title: 'Item 3'},
- *                     {title: 'Item 4'}
- *                 ] 
- *             });
- *         }
- *         readylistView(event) {
- *             this.listView = event.detail.cmp;
- *             this.listView.setStore(this.store);
- *             this.listView.setItemTpl(`{title}`);
- *         }
- *     }
- *      ```
+ *export default class BasicListComponent {
+ *    constructor() {
+ *        this.store = new Ext.data.Store({
+ *            data: [
+ *               {title: 'Item 1'},
+ *               {title: 'Item 2'},
+ *               {title: 'Item 3'},
+ *               {title: 'Item 4'}
+ *           ] 
+ *       });
+ *    }
+ *    readylistView(event) {
+ *        this.listView = event.detail.cmp;
+ *        this.listView.setStore(this.store);
+ *        this.listView.setItemTpl(`{title}`);
+ *    }
+ *}
+ *```
  */
 
  /**   A more advanced example showing a list of people grouped by last name:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-list
- *          grouped="true"
- *          onready="groupedlist.readyGroupedListView"
- *      >
- *      </ext-list>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-list.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-list
+ *    grouped="true"
+ *    onready="groupedlist.readyGroupedListView"
+ *>
+ *</ext-list>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-list.component';
  * 
- *      export default class GroupedListComponent {
- *          constructor() {
- *              this.store = new Ext.data.Store({
- *                  data: [{
- *                     firstName: 'Peter',
- *                     lastName: 'Venkman'
- *                  }, {
- *                     firstName: 'Raymond',
- *                     lastName: 'Stantz'
- *                  }, {
- *                     firstName: 'Egon',
- *                     lastName: 'Spengler'
- *                  }, {
- *                     firstName: 'Winston',
- *                     lastName: 'Zeddemore'
- *                 }],
+ *export default class GroupedListComponent {
+ *    constructor() {
+ *        this.store = new Ext.data.Store({
+ *            data: [{
+ *               firstName: 'Peter',
+ *               lastName: 'Venkman'
+ *            }, {
+ *               firstName: 'Raymond',
+ *               lastName: 'Stantz'
+ *            }, {
+ *               firstName: 'Egon',
+ *               lastName: 'Spengler'
+ *            }, {
+ *               firstName: 'Winston',
+ *               lastName: 'Zeddemore'
+ *           }],
  *
- *                 sorters: 'lastName',
+ *           sorters: 'lastName',
  *
- *                 grouper: {
- *                     groupFn: function(record) {
- *                         return record.get('lastName')[0];
- *                     }
- *                 }
- *             });
- *         }
+ *           grouper: {
+ *               groupFn: function(record) {
+ *                   return record.get('lastName')[0];
+ *               }
+ *           }
+ *       });
+ *   }
  * 
- *          readyGroupedListView(event) {
- *             this.groupedlistView = event.detail.cmp;
- *             this.groupedlistView.setStore(this.store);
- *             this.groupedlistView.setItemTpl(`{firstName} {lastName}`);
- *          }
- *      }
- *      ```
+ *   readyGroupedListView(event) {
+ *       this.groupedlistView = event.detail.cmp;
+ *       this.groupedlistView.setStore(this.store);
+ *       this.groupedlistView.setItemTpl(`{firstName} {lastName}`);
+ *   }
+ *}
+ *```
  */
 
  /**
  * If you want to dock items to the bottom or top of a List, you can use the scrollDock configuration on child items in this List. The following example adds a button to the bottom of the List.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-list
- *          onready="positionlistitem.readyPositionedListView"
- *      >
- *          <ext-button
- *             scrollDock="bottom"
- *             docked="bottom"
- *             text="load more..."
- *          >
- *          </ext-button>
- *      </ext-list>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-list.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-list
+ *    onready="positionlistitem.readyPositionedListView"
+ *>
+ *    <ext-button
+ *       scrollDock="bottom"
+ *       docked="bottom"
+ *       text="load more..."
+ *    >
+ *    </ext-button>
+ *</ext-list>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-list.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
  * 
- *      export default class PositionedListItemComponent {
+ *export default class PositionedListItemComponent {
  * 
- *          constructor() {
- *              this.store = new Ext.data.store({
- *                  data: [{
- *                      firstName: 'Peter',
- *                      lastName: 'Venkman'
- *                   },    
- *                   {
- *                      firstName: 'Raymond',
- *                      lastName: 'Stantz'
- *                   },
- *                   {
- *                      firstName: 'Egon',
- *                      lastName: 'Spengler'
- *                   },
- *                   {
- *                      firstName: 'Winston',
- *                      lastName: 'Zeddemore'
- *                 }]
- *             })
+ *    constructor() {
+ *        this.store = new Ext.data.store({
+ *            data: [{
+ *                firstName: 'Peter',
+ *                lastName: 'Venkman'
+ *             },    
+ *             {
+ *                firstName: 'Raymond',
+ *                lastName: 'Stantz'
+ *             },
+ *             {
+ *                firstName: 'Egon',
+ *                lastName: 'Spengler'
+ *             },
+ *             {
+ *                firstName: 'Winston',
+ *                lastName: 'Zeddemore'
+ *           }]
+ *       })
  * 
- *         }
+ *   }
  * 
- *         readyPositionedListView(event) {
- *              this.positionedListView = event.detail.cmp;
- *              this.positionedListView.setStore(this.store);
- *              this.positionedListView.setItemTpl(`{firstName} {lastName}`);
- *         }
- *     }
- *      ```
+ *   readyPositionedListView(event) {
+ *        this.positionedListView = event.detail.cmp;
+ *        this.positionedListView.setStore(this.store);
+ *        this.positionedListView.setItemTpl(`{firstName} {lastName}`);
+ *   }
+ *}
+ *```
  * 
  */
 

--- a/api-docs/modern/modern/src/dataview/NestedList.js
+++ b/api-docs/modern/modern/src/dataview/NestedList.js
@@ -6,62 +6,62 @@
  * NestedList provides a miller column interface to navigate between nested sets
  * and provide a clean interface with limited screen real-estate.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-nestedlist
- *              displayField="text"
- *              title="Groceries"
- *              onready="nestedlist.readyNestedList"
- *          >
- *          </ext-nestedlist>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-nestedlist.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-nestedlist
+ *        displayField="text"
+ *        title="Groceries"
+ *        onready="nestedlist.readyNestedList"
+ *    >
+ *    </ext-nestedlist>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-nestedlist.component';
  * 
- *      export default class NestedListComponent {
- *          constructor() {
- *              this.store = Ext.create('Ext.data.TreeStore', {
- *                  defaultRootProperty: 'items',
- *                  root: {
- *                      text: 'Groceries',
- *                      items: [{
- *                          text: 'Drinks',
- *                          items: [{
- *                              text: 'Water',
- *                              items: [{
- *                                  text: 'Sparkling',
- *                                  leaf: true
- *                              }, {
- *                                  text: 'Still',
- *                                  leaf: true
- *                              }]
- *                          }]
- *                      },{
- *                      text: 'Snacks',
- *                      items: [{
- *                          text: 'Nuts',
- *                          leaf: true
- *                       }, {
- *                          text: 'Pretzels',
- *                          leaf: true
- *                       }, {
- *                          text: 'Wasabi Peas',
- *                          leaf: true
- *                       }]
- *                     }]
- *                 }
- *              });
- *         }
- *         readyNestedList(event) {
- *             this.nestedListView = event.detail.cmp;
- *             this.nestedListView.setStore(this.store);
- *         }  
- *      }
- *      ```
+ *export default class NestedListComponent {
+ *    constructor() {
+ *        this.store = Ext.create('Ext.data.TreeStore', {
+ *            defaultRootProperty: 'items',
+ *            root: {
+ *                text: 'Groceries',
+ *                items: [{
+ *                    text: 'Drinks',
+ *                    items: [{
+ *                        text: 'Water',
+ *                        items: [{
+ *                            text: 'Sparkling',
+ *                            leaf: true
+ *                        }, {
+ *                            text: 'Still',
+ *                            leaf: true
+ *                        }]
+ *                    }]
+ *                },{
+ *                text: 'Snacks',
+ *                items: [{
+ *                    text: 'Nuts',
+ *                    leaf: true
+ *                 }, {
+ *                    text: 'Pretzels',
+ *                    leaf: true
+ *                 }, {
+ *                    text: 'Wasabi Peas',
+ *                    leaf: true
+ *                 }]
+ *               }]
+ *           }
+ *        });
+ *   }
+ *   readyNestedList(event) {
+ *       this.nestedListView = event.detail.cmp;
+ *       this.nestedListView.setStore(this.store);
+ *   }  
+ *}
+ *```
  *
  */
 

--- a/api-docs/modern/modern/src/field/Checkbox.js
+++ b/api-docs/modern/modern/src/field/Checkbox.js
@@ -9,28 +9,28 @@
  * {@link Ext.field.Field field} and is usually found in the context of a form:
  *
  * ## Example
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel
- *              shadow="true"
- *              layout='{"type": "vbox", align: "left"}'
- *           >  
- *              <ext-checkboxfield boxLabel="Unchecked"></ext-checkboxfield>
- *              <ext-checkboxfield boxLabel="Checked" checked></ext-checkboxfield>
- *              <ext-checkboxfield boxLabel="Disabled" disabled></ext-checkboxfield>
- *              <ext-checkboxfield boxLabel="Disabled (checked)" disabled checked></ext-checkboxfield>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-checkboxfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel
+ *        shadow="true"
+ *        layout='{"type": "vbox", align: "left"}'
+ *     >  
+ *        <ext-checkboxfield boxLabel="Unchecked"></ext-checkboxfield>
+ *        <ext-checkboxfield boxLabel="Checked" checked></ext-checkboxfield>
+ *        <ext-checkboxfield boxLabel="Disabled" disabled></ext-checkboxfield>
+ *        <ext-checkboxfield boxLabel="Disabled (checked)" disabled checked></ext-checkboxfield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-checkboxfield.component';
  * 
- *      export default class CheckBoxFieldComponent {}
- *     ```
+ *export default class CheckBoxFieldComponent {}
+ *```
  *
  */
 

--- a/api-docs/modern/modern/src/field/ComboBox.js
+++ b/api-docs/modern/modern/src/field/ComboBox.js
@@ -22,44 +22,44 @@
  * set the {@link #queryMode} to `'local'`.
  *
  * # Example usage:
- *      HTML
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-formpanel
- *          shadow="true"
- *      >
- *          <ext-combobox
- *              width="200"
- *              label="State"
- *              displayField="name"
- *              valueField="code"
- *              queryMode="local"
- *              labelAlign="placeholder"
- *              typeAhead="true"
- *              onready="comboboxfield.comboboxFieldReady"
- *           >
- *           </ext-combobox>
- *      </ext-formpanel>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-combobox.component';
+ *HTML
+ *```HTML
+ *@example({tab: 1})
+ *<ext-formpanel
+ *    shadow="true"
+ *>
+ *    <ext-combobox
+ *        width="200"
+ *        label="State"
+ *        displayField="name"
+ *        valueField="code"
+ *        queryMode="local"
+ *        labelAlign="placeholder"
+ *        typeAhead="true"
+ *        onready="comboboxfield.comboboxFieldReady"
+ *     >
+ *     </ext-combobox>
+ *</ext-formpanel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-combobox.component';
  *
- *      export default class ComboBoxFieldComponent {
- *          constructor() {
- *               this.data = [
- *                   {"name":"Alabama","abbrev":"AL"},
- *                   {"name":"Alaska","abbrev":"AK"},
- *                   {"name":"Arizona","abbrev":"AZ"}
- *               ]
- *         }
- *         comboboxFieldReady(event) {
- *             this.combobox = event.detail.cmp;
- *             this.combobox.setOptions(this.data);
- *         }
- *      }
- *      ```
+ *export default class ComboBoxFieldComponent {
+ *    constructor() {
+ *         this.data = [
+ *             {"name":"Alabama","abbrev":"AL"},
+ *             {"name":"Alaska","abbrev":"AK"},
+ *             {"name":"Arizona","abbrev":"AZ"}
+ *         ]
+ *   }
+ *   comboboxFieldReady(event) {
+ *       this.combobox = event.detail.cmp;
+ *       this.combobox.setOptions(this.data);
+ *   }
+ *}
+ *```
  *
  */
 

--- a/api-docs/modern/modern/src/field/Date.js
+++ b/api-docs/modern/modern/src/field/Date.js
@@ -17,38 +17,38 @@
  * the current date. You can also use the {@link #setValue} method to update the value
  * at any time.
  *
- *      ```HTML
- *      @example({tab: 1})
- *     <ext-container layout="center">
- *         <ext-formpanel
- *             shadow="true"
- *         >
- *             <ext-datepickerfield
- *                 width="150"
- *                 destroyPickerOnHide="true"
- *                 onready="datepickerfield.onReadyDatePickerField()"
- *                 label="Date"
- *                 picker='{
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel
+ *        shadow="true"
+ *    >
+ *        <ext-datepickerfield
+ *            width="150"
+ *            destroyPickerOnHide="true"
+ *            onready="datepickerfield.onReadyDatePickerField()"
+ *            label="Date"
+ *            picker='{
  *                           yearFrom: 1990
  *                         }'
- *              >
- *             </ext-datepickerfield>
- *         </ext-formpanel>
- *     </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-datepickerfield.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *         >
+ *        </ext-datepickerfield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-datepickerfield.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
  * 
- *      export default class DatePickerFieldComponent {
- *          onReadyDatePickerField(event) {
- *              this.datepickerfieldView = event.detail.cmp;
- *              this.datepickerfieldView.setValue(new Date());
- *          }
- *      }
- *      ```
+ *export default class DatePickerFieldComponent {
+ *    onReadyDatePickerField(event) {
+ *        this.datepickerfieldView = event.detail.cmp;
+ *        this.datepickerfieldView.setValue(new Date());
+ *    }
+ *}
+ *```
  * 
  */
 

--- a/api-docs/modern/modern/src/field/Email.js
+++ b/api-docs/modern/modern/src/field/Email.js
@@ -7,31 +7,31 @@
  * Because it creates an HTML email input field, most browsers will show a specialized
  * virtual keyboard for email address input. Aside from that, the email field is just a
  * normal text field. Here's an example of how to use it in a form:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container
- *          layout="center"
- *       >
- *          <ext-formpanel
- *               shadow="true"
- *           >
- *              <ext-emailfield
- *                   width="250"
- *                   placeholder="user@domain.com"
- *                   label="Email"
- *               >
- *              </ext-emailfield>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-emailfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container
+ *    layout="center"
+ *>
+ *   <ext-formpanel
+ *         shadow="true"
+ *    >
+ *       <ext-emailfield
+ *            width="250"
+ *            placeholder="user@domain.com"
+ *            label="Email"
+ *        >
+ *       </ext-emailfield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-emailfield.component';
  * 
- *      export default class EmailFieldComponent {}
- *      ```
+ *export default class EmailFieldComponent {}
+ *```
  *
  */
 /**

--- a/api-docs/modern/modern/src/field/File.js
+++ b/api-docs/modern/modern/src/field/File.js
@@ -5,27 +5,27 @@
  *
  * Creates an HTML file input field on the page. This is usually used to upload files to remote server. File fields are usually
  * created inside a form like this:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-filefield
- *                   label="Select a File"
- *                   name="photo"
- *                   accept="image"
- *               >
- *               </ext-filefield>
- *          <ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-filefield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-filefield
+ *             label="Select a File"
+ *             name="photo"
+ *             accept="image"
+ *         >
+ *         </ext-filefield>
+ *    <ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-filefield.component';
  * 
- *      export default class FileFieldComponent {}
- *      ```
+ *export default class FileFieldComponent {}
+ *```
  *
  */
 

--- a/api-docs/modern/modern/src/field/Hidden.js
+++ b/api-docs/modern/modern/src/field/Hidden.js
@@ -8,26 +8,26 @@
  * dynamic or previously collected data back to the server in the same request as the
  * normal form submission. For example, here is how we might set up a form to send
  * back a hidden userId field:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-hiddenfield
- *                   value="123"
- *                   name="hide"
- *               >
- *              </ext-hiddenfield>
- *          <ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-hiddenfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-hiddenfield
+ *             value="123"
+ *             name="hide"
+ *         >
+ *        </ext-hiddenfield>
+ *    <ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-hiddenfield.component';
  * 
- *      export default class HiddenFieldComponent {}
- *      ```
+ *export default class HiddenFieldComponent {}
+ *```
  *
  */
 /*

--- a/api-docs/modern/modern/src/field/Number.js
+++ b/api-docs/modern/modern/src/field/Number.js
@@ -7,26 +7,26 @@
  * number input field, most browsers will show a specialized virtual keyboard for entering numbers. The Number field
  * only accepts numerical input and also provides additional spinner UI that increases or decreases the current value
  * by a configured {@link #stepValue step value}. Here's how we might use one in a form:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-numberfield
- *                   label="Number"
- *                   width="150"
- *               >
- *              </ext-numberfield>
- *          <ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-numberfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-numberfield
+ *             label="Number"
+ *             width="150"
+ *         >
+ *        </ext-numberfield>
+ *    <ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-numberfield.component';
  * 
- *      export default class NumberFieldComponent {}
- *      ```
+ *export default class NumberFieldComponent {}
+ *```
  *
  */
 /**

--- a/api-docs/modern/modern/src/field/Password.js
+++ b/api-docs/modern/modern/src/field/Password.js
@@ -7,28 +7,28 @@
  * Because it creates a password field, when the user enters text it will show up as
  * stars. Aside from that, the password field is just a normal text field. Here's an
  * example of how to use it in a form:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-passwordfield
- *                   width="200"
- *                   label="Password"
- *                   required="true"
- *                   revealable="true"
- *              >
- *              <ext-passwordfield>
- *          <ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-passwordfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-passwordfield
+ *             width="200"
+ *             label="Password"
+ *             required="true"
+ *             revealable="true"
+ *        >
+ *        <ext-passwordfield>
+ *    <ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-passwordfield.component';
  * 
- *      export default class PasswordFieldComponent {}
- *      ```
+ *export default class PasswordFieldComponent {}
+ *```
  *
  */
 /**

--- a/api-docs/modern/modern/src/field/Radio.js
+++ b/api-docs/modern/modern/src/field/Radio.js
@@ -7,44 +7,44 @@
  * The radio field is an enhanced version of the native browser radio controls and is a
  * good way of allowing your user to choose one option out of a selection of several
  * (for example, choosing a favorite color):
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel
- *               shadow="true"
- *               layout='{"type": "vbox", "align": "left"}'
- *          >
- *              <ext-radiofield
- *                 name="radios"
- *                 boxLabel="Checked"
- *                 value="checked"
- *                 checked="true"
- *              >
- *              </ext-radiofield>
- *              <ext-radiofield
- *                  name="radios"
- *                  boxLabel="Unchecked"
- *                  value="unchecked"
- *              >
- *              </ext-radiofield>
- *              <ext-radiofield
- *                  name="radios"
- *                  boxLabel="Disabled"
- *                  value="disabled"
- *                  disabled="true"
- *              >
- *              </ext-radiofield>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-radiofield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel
+ *         shadow="true"
+ *         layout='{"type": "vbox", "align": "left"}'
+ *    >
+ *        <ext-radiofield
+ *           name="radios"
+ *           boxLabel="Checked"
+ *           value="checked"
+ *           checked="true"
+ *        >
+ *        </ext-radiofield>
+ *        <ext-radiofield
+ *            name="radios"
+ *            boxLabel="Unchecked"
+ *            value="unchecked"
+ *        >
+ *        </ext-radiofield>
+ *        <ext-radiofield
+ *            name="radios"
+ *            boxLabel="Disabled"
+ *            value="disabled"
+ *            disabled="true"
+ *        >
+ *        </ext-radiofield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-radiofield.component';
  * 
- *      export default class RadioFieldComponent {}
- *      ```
+ *export default class RadioFieldComponent {}
+ *```
  *
  */
 

--- a/api-docs/modern/modern/src/field/Search.js
+++ b/api-docs/modern/modern/src/field/Search.js
@@ -9,46 +9,46 @@
  *
  * As with all other form fields, the search field gains a "clear" button that appears whenever there
  * is text entered into the form, and which removes that text when tapped.
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-searchfield
- *                   width="300"
- *                   placeholder="Search..."
- *                   onChange="searchfield.search"
- *                   onready="searchfield.searchFieldReady()"
- *              >
- *              <ext-searchfield>
- *              <ext-container
- *                  onready="searchfield.searchMessageReady()"
- *              >
- *              </ext-container>
- *          <ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-searchfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-searchfield
+ *             width="300"
+ *             placeholder="Search..."
+ *             onChange="searchfield.search"
+ *             onready="searchfield.searchFieldReady()"
+ *        >
+ *        <ext-searchfield>
+ *        <ext-container
+ *            onready="searchfield.searchMessageReady()"
+ *        >
+ *        </ext-container>
+ *    <ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-searchfield.component';
  * 
- *      export default class SearchFieldComponent {
+ *export default class SearchFieldComponent {
  * 
- *          search = (field, value) => {
- *             this.searchFieldView.setValue(value);
- *             this.searchMessage.setHTML(`<div>You searched for ${value} </div>`);
- *          }
+ *    search = (field, value) => {
+ *       this.searchFieldView.setValue(value);
+ *       this.searchMessage.setHTML(`<div>You searched for ${value} </div>`);
+ *    }
  * 
- *          searchFieldReady = (event) => {
- *              this.searchFieldView = event.detail.cmp;
- *          }
+ *    searchFieldReady = (event) => {
+ *        this.searchFieldView = event.detail.cmp;
+ *    }
  * 
- *          searchMessageRead = (event) => {
- *              this.searchMessage = event.detail.cmp;
- *          }
- *      }
- *      ```
+ *    searchMessageRead = (event) => {
+ *        this.searchMessage = event.detail.cmp;
+ *    }
+ *}
+ *```
  *
  */
 /**

--- a/api-docs/modern/modern/src/field/Select.js
+++ b/api-docs/modern/modern/src/field/Select.js
@@ -4,41 +4,41 @@
  * @xtype selectfield
  *
  * Simple Select field wrapper. Example usage:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-selectfield
- *                   label="Select"
- *                   width="200"
- *                   onChange="selectfield.onchangeselectfield"
- *              >
- *              <ext-selectfield>
- *          <ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-selectfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-selectfield
+ *             label="Select"
+ *             width="200"
+ *             onChange="selectfield.onchangeselectfield"
+ *        >
+ *        <ext-selectfield>
+ *    <ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-selectfield.component';
  * 
- *      export default class SelectFieldComponent {
+ *export default class SelectFieldComponent {
  *      
- *          selectFieldReady(event) {
- *              this.selectFieldView = event.detail.cmp;
- *              this.selectFieldView.setOptions([  
- *                      { text: "Option 1", value: 1 },
- *                      { text: "Option 2", value: 2 },
- *                      { text: "Option 3", value: 3 }
- *                  ]);
- *          }
+ *    selectFieldReady(event) {
+ *        this.selectFieldView = event.detail.cmp;
+ *        this.selectFieldView.setOptions([  
+ *                { text: "Option 1", value: 1 },
+ *                { text: "Option 2", value: 2 },
+ *                { text: "Option 3", value: 3 }
+ *            ]);
+ *    }
  * 
- *          onchangeselectfield = (event) => {
- *               return Ext.toast(`You selected the item with value ${event.detail.newValue}`);
- *          }
- *      }
- *      ```
+ *    onchangeselectfield = (event) => {
+ *         return Ext.toast(`You selected the item with value ${event.detail.newValue}`);
+ *    }
+ *}
+ *```
  *
  */
 

--- a/api-docs/modern/modern/src/field/Slider.js
+++ b/api-docs/modern/modern/src/field/Slider.js
@@ -8,77 +8,77 @@
  * color. Each slider contains a single 'thumb' that can be dragged along the slider's length to change the value.
  * Sliders are equally useful inside {@link Ext.form.Panel forms} and standalone. Here's how to quickly create a
  * slider in form, in this case enabling a user to choose a percentage:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel
- *               shadow="true"
- *               width="300"
- *          >
- *              <ext-sliderfield
- *                   onChange="sliderfield.onSingleChange"
- *                   label="Single Thumb"
- *                   onready="sliderfield.readySingleChangeSliderField"
- *              >
- *              </ext-sliderfield>
- *              <ext-container
- *                  style='{marginBottom: "20px"}'
- *                  onready="readySingleValueMessage"
- *              >
- *              </ext-container>
- *              <ext-sliderfield
- *                   onChange="sliderfield.onMultipleChange"
- *                   label="Multiple Thumbs"
- *                   onready="sliderfield.readyMultipleChangeSliderField"
- *              >
- *              </ext-sliderfield>
- *              <ext-container
- *                   onready="sliderfield.readyMultipleValueMessage"
- *              >
- *              </ext-container>
- *          <ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-sliderfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel
+ *         shadow="true"
+ *         width="300"
+ *    >
+ *        <ext-sliderfield
+ *             onChange="sliderfield.onSingleChange"
+ *             label="Single Thumb"
+ *             onready="sliderfield.readySingleChangeSliderField"
+ *        >
+ *        </ext-sliderfield>
+ *        <ext-container
+ *            style='{marginBottom: "20px"}'
+ *            onready="readySingleValueMessage"
+ *        >
+ *        </ext-container>
+ *        <ext-sliderfield
+ *             onChange="sliderfield.onMultipleChange"
+ *             label="Multiple Thumbs"
+ *             onready="sliderfield.readyMultipleChangeSliderField"
+ *        >
+ *        </ext-sliderfield>
+ *        <ext-container
+ *             onready="sliderfield.readyMultipleValueMessage"
+ *        >
+ *        </ext-container>
+ *    <ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-sliderfield.component';
  * 
- *      export default class SliderFieldComponent {
+ *export default class SliderFieldComponent {
  * 
- *         constructor() {
- *             this.multipleValue = [10, 70];
- *         }
+ *   constructor() {
+ *       this.multipleValue = [10, 70];
+ *   }
  *          
- *         onSingleChange = (field, value) => {
- *             this.singleValueSliderFieldView.setValue(value);
- *             this.singleValueMessaageView.setHTML(`Values: ${value}`)
- *         }
+ *   onSingleChange = (field, value) => {
+ *       this.singleValueSliderFieldView.setValue(value);
+ *       this.singleValueMessaageView.setHTML(`Values: ${value}`)
+ *   }
  *
- *         readySingleChangeSliderField = (event) => {
- *             this.singleValueSliderFieldView = event.detail.cmp;
- *         }
+ *   readySingleChangeSliderField = (event) => {
+ *       this.singleValueSliderFieldView = event.detail.cmp;
+ *   }
  *  
- *         readyMultipleChangeSliderField = (event) => {
- *             this.multipleValueSliderFieldView = event.detail.cmp;
- *         }
+ *   readyMultipleChangeSliderField = (event) => {
+ *       this.multipleValueSliderFieldView = event.detail.cmp;
+ *   }
  * 
- *         onMultipleChange = (field, value) => {
- *             this.multipleValue.push(value);
- *             this.multipleValueSliderFieldView.setValue(value);
- *             this.multipleValueMessaageView.setHTML(`Values: ${this.multipleValue.join(',')}`)
- *         }
+ *   onMultipleChange = (field, value) => {
+ *       this.multipleValue.push(value);
+ *       this.multipleValueSliderFieldView.setValue(value);
+ *       this.multipleValueMessaageView.setHTML(`Values: ${this.multipleValue.join(',')}`)
+ *   }
  * 
- *         readyMultipleValueMessage = (event) => {
- *              this.singleValueMessaageView = event.detail.cmp;
- *         }
+ *   readyMultipleValueMessage = (event) => {
+ *        this.singleValueMessaageView = event.detail.cmp;
+ *   }
  * 
- *         readySingleValueMessage = (event) => {
- *              this.multipleValueMessaageView = event.detail.cmp;
- *         }
- *      }
- *      ```
+ *   readySingleValueMessage = (event) => {
+ *        this.multipleValueMessaageView = event.detail.cmp;
+ *   }
+ *}
+ *```
  *
  */
 

--- a/api-docs/modern/modern/src/field/Spinner.js
+++ b/api-docs/modern/modern/src/field/Spinner.js
@@ -4,29 +4,29 @@
  * @xtype spinnerfield
  *
  * Wraps an HTML5 number field. Example usage:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-spinnerfield
- *                  label="Spinner"
- *                  width="150"
- *                  minValue="1"
- *                  maxValue="10"
- *                  stepValue="1"
- *              >
- *              </ext-spinnerfield>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-spinnerfield
+ *            label="Spinner"
+ *            width="150"
+ *            minValue="1"
+ *            maxValue="10"
+ *            stepValue="1"
+ *        >
+ *        </ext-spinnerfield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
  *
- *      export default class SpinnerFieldComponent {}
- *      ```
+ *export default class SpinnerFieldComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/field/Text.js
+++ b/api-docs/modern/modern/src/field/Text.js
@@ -7,39 +7,39 @@
  * functionality such as input validation, standard events, state management and look
  * and feel. Typically we create text fields inside a form, like this:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-fieldset title="Separate Label and Placeholder" margin="0 0 20 0">
- *                  <ext-textfield placeHolder="Enter Name..." label="Name" required="true"></ext-textfield>
- *              </ext-fieldset>
- *              <ext-fieldset title="Label as Placeholder" margin="0 0 20 0">
- *                  <ext-textfield labelAlign="placeholder" label="Name" required="true"></ext-textfield>
- *              </ext-fieldset>
- *              <ext-fieldset title="With Error Message">
- *                  <ext-textfield
- *                      labelAlign="placeholder"
- *                      label="Label"
- *                      value="invalid value"
- *                      errorTarget="under"
- *                      required="true"
- *                      errorMessage="The value you entered is invalid."
- *                  >
- *                  </ext-textfield>
- *              </ext-fieldset>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-textfield.component';
- *      import '@sencha/ext-web-components/dist/ext-fieldset.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-fieldset title="Separate Label and Placeholder" margin="0 0 20 0">
+ *            <ext-textfield placeHolder="Enter Name..." label="Name" required="true"></ext-textfield>
+ *        </ext-fieldset>
+ *        <ext-fieldset title="Label as Placeholder" margin="0 0 20 0">
+ *            <ext-textfield labelAlign="placeholder" label="Name" required="true"></ext-textfield>
+ *        </ext-fieldset>
+ *        <ext-fieldset title="With Error Message">
+ *            <ext-textfield
+ *                labelAlign="placeholder"
+ *                label="Label"
+ *                value="invalid value"
+ *                errorTarget="under"
+ *                required="true"
+ *                errorMessage="The value you entered is invalid."
+ *            >
+ *            </ext-textfield>
+ *        </ext-fieldset>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-textfield.component';
+ *import '@sencha/ext-web-components/dist/ext-fieldset.component';
  *
- *      export default class TextFieldComponent {}
- *      ```
+ *export default class TextFieldComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/field/TextArea.js
+++ b/api-docs/modern/modern/src/field/TextArea.js
@@ -10,27 +10,27 @@
  * input methods like select boxes or radio buttons are not possible. Text Areas are
  * usually created inside forms, like this:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-textareafield
- *                  label="Description"
- *                  width="300"
- *                  maxRows="10"
- *              >
- *              </ext-textareafield>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-textareafield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-textareafield
+ *            label="Description"
+ *            width="300"
+ *            maxRows="10"
+ *        >
+ *        </ext-textareafield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-textareafield.component';
  *
- *      export default class TextAreaFieldComponent {}
- *      ```
+ *export default class TextAreaFieldComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/field/Toggle.js
+++ b/api-docs/modern/modern/src/field/Toggle.js
@@ -5,25 +5,25 @@
  *
  * Specialized {@link Ext.field.Slider} with a single thumb which only supports two
  * {@link #value values}.
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-togglefield boxLabel="On" value="true"></ext-togglefield>
- *              <ext-togglefield boxLabel="Off" value="false"></ext-togglefield>
- *              <ext-togglefield boxLabel="Disabled" disabled="true"></ext-togglefield>
- *              <ext-togglefield boxLabel="Disabled (On)" disabled="true" value="true"></ext-togglefield>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-togglefield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-togglefield boxLabel="On" value="true"></ext-togglefield>
+ *        <ext-togglefield boxLabel="Off" value="false"></ext-togglefield>
+ *        <ext-togglefield boxLabel="Disabled" disabled="true"></ext-togglefield>
+ *        <ext-togglefield boxLabel="Disabled (On)" disabled="true" value="true"></ext-togglefield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-togglefield.component';
  *
- *      export default class ToggleFieldComponent {}
- *      ```
+ *export default class ToggleFieldComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/field/Url.js
+++ b/api-docs/modern/modern/src/field/Url.js
@@ -7,22 +7,22 @@
  * field, most browsers will show a specialized virtual keyboard for web address input. Aside from that, the url field
  * is just a normal text field. Here's an example of how to use it in a form:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-urlfield placeholder="http://www.domain.com" label="URL" width="200"></ext-urlfield>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-urlfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-urlfield placeholder="http://www.domain.com" label="URL" width="200"></ext-urlfield>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-urlfield.component';
  *
- *      export default class URLFieldComponent {}
- *      ```
+ *export default class URLFieldComponent {}
+ *```
  *
  * Because url field inherits from {@link Ext.field.Text textfield} it gains all of the functionality that text fields
  * provide, including getting and setting the value at runtime, validations and various events that are fired as the

--- a/api-docs/modern/modern/src/form/FieldSet.js
+++ b/api-docs/modern/modern/src/form/FieldSet.js
@@ -9,26 +9,26 @@
  * optionally have a title at the top and instructions at the bottom. Here's how we might create a FieldSet inside a
  * form:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center">
- *          <ext-formpanel shadow="true">
- *              <ext-fieldset title="About You" instructions="Tell us about yourself." width="300">
- *                  <ext-textfield label="First Name" labelAlign="placeholder"></ext-textfield>
- *                  <ext-textfield label="Last Name" labelAlign="placeholder"></ext-textfield>
- *              </ext-fieldset>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-fieldset.component';
- *      import '@sencha/ext-web-components/dist/ext-textfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center">
+ *    <ext-formpanel shadow="true">
+ *        <ext-fieldset title="About You" instructions="Tell us about yourself." width="300">
+ *            <ext-textfield label="First Name" labelAlign="placeholder"></ext-textfield>
+ *            <ext-textfield label="Last Name" labelAlign="placeholder"></ext-textfield>
+ *        </ext-fieldset>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-fieldset.component';
+ *import '@sencha/ext-web-components/dist/ext-textfield.component';
  *
- *      export default class FieldSetComponent {}
- *      ```
+ *export default class FieldSetComponent {}
+ *```
  *
  * Above we created a {@link Ext.form.Panel form} with a fieldset that contains two text fields. In this case, all
  * of the form fields are in the same fieldset, but for longer forms we may choose to use multiple fieldsets. We also

--- a/api-docs/modern/modern/src/form/Panel.js
+++ b/api-docs/modern/modern/src/form/Panel.js
@@ -5,25 +5,25 @@
  *
  * The Form panel presents a set of form fields and provides convenient ways to load and save data. Usually a form
  * panel just contains the set of fields you want to display.
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="center" width="100%" height="100%">
- *          <ext-formpanel title="Form Panel">
- *              <ext-textfield label="First Name"></ext-textfield>
- *              <ext-textfield label="Last Name"></ext-textfield>
- *              <ext-textfield label="Account Number"></ext-textfield>
- *              <ext-button text="Submit"></ext-button>
- *          </ext-formpanel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-textfield.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="center" width="100%" height="100%">
+ *    <ext-formpanel title="Form Panel">
+ *        <ext-textfield label="First Name"></ext-textfield>
+ *        <ext-textfield label="Last Name"></ext-textfield>
+ *        <ext-textfield label="Account Number"></ext-textfield>
+ *        <ext-button text="Submit"></ext-button>
+ *    </ext-formpanel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-textfield.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
  *
- *      export default class PanelComponent {}
- *      ```
+ *export default class PanelComponent {}
+ *```
  *
  * ##Loading data
  *

--- a/api-docs/modern/modern/src/grid/Grid.js
+++ b/api-docs/modern/modern/src/grid/Grid.js
@@ -11,40 +11,40 @@
  * a set of columns to render.
  *
  * ## A Basic Grid
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid shadow="true" height="100%" onready="basicgrid.onGridReady">
- *              <ext-column text="Name" dataIndex="name" flex="1"></ext-column>
- *              <ext-column text="Email" dataIndex="email" flex="1"></ext-column>
- *              <ext-column text="Phone" dataIndex="phone" flex="1"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid shadow="true" height="100%" onready="basicgrid.onGridReady">
+ *        <ext-column text="Name" dataIndex="name" flex="1"></ext-column>
+ *        <ext-column text="Email" dataIndex="email" flex="1"></ext-column>
+ *        <ext-column text="Phone" dataIndex="phone" flex="1"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      export default class BasicGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                data: [
- *                    { "name": "Lisa", "email": "lisa@simpsons.com", "phone": "555-111-1224" },
- *                    { "name": "Bart", "email": "bart@simpsons.com", "phone": "555-222-1234" },
- *                    { "name": "Homer", "email": "home@simpsons.com", "phone": "555-222-1244" },
- *                    { "name": "Marge", "email": "marge@simpsons.com", "phone": "555-222-1254" }
- *                ]
- *             });
- *          }
+ *export default class BasicGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          data: [
+ *              { "name": "Lisa", "email": "lisa@simpsons.com", "phone": "555-111-1224" },
+ *              { "name": "Bart", "email": "bart@simpsons.com", "phone": "555-222-1234" },
+ *              { "name": "Homer", "email": "home@simpsons.com", "phone": "555-222-1244" },
+ *              { "name": "Marge", "email": "marge@simpsons.com", "phone": "555-222-1254" }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.basicGridCmp = event.detail.cmp;
- *              this.basicGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.basicGridCmp = event.detail.cmp;
+ *        this.basicGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  *
  * The code above produces a simple grid with three columns. We specified a Store which will
  * load JSON data inline.
@@ -61,40 +61,40 @@
  * A top-level column definition may contain a `columns` configuration. This means that the
  * resulting header will be a group header, and will contain the child columns.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid shadow="true" height="100%" onready="basicgrid.onGridReady">
- *              <ext-column text="Name" dataIndex="name" flex="1"></ext-column>
- *              <ext-column text="Email" dataIndex="email" flex="1" hidden="true"></ext-column>
- *              <ext-column text="Phone" dataIndex="phone" flex="1"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid shadow="true" height="100%" onready="basicgrid.onGridReady">
+ *        <ext-column text="Name" dataIndex="name" flex="1"></ext-column>
+ *        <ext-column text="Email" dataIndex="email" flex="1" hidden="true"></ext-column>
+ *        <ext-column text="Phone" dataIndex="phone" flex="1"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      export default class BasicGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                data: [
- *                    { "name": "Lisa", "email": "lisa@simpsons.com", "phone": "555-111-1224" },
- *                    { "name": "Bart", "email": "bart@simpsons.com", "phone": "555-222-1234" },
- *                    { "name": "Homer", "email": "home@simpsons.com", "phone": "555-222-1244" },
- *                    { "name": "Marge", "email": "marge@simpsons.com", "phone": "555-222-1254" }
- *                ]
- *             });
- *          }
+ *export default class BasicGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          data: [
+ *              { "name": "Lisa", "email": "lisa@simpsons.com", "phone": "555-111-1224" },
+ *              { "name": "Bart", "email": "bart@simpsons.com", "phone": "555-222-1234" },
+ *              { "name": "Homer", "email": "home@simpsons.com", "phone": "555-222-1244" },
+ *              { "name": "Marge", "email": "marge@simpsons.com", "phone": "555-222-1254" }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.basicGridCmp = event.detail.cmp;
- *              this.basicGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.basicGridCmp = event.detail.cmp;
+ *        this.basicGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  *
  * ## Rows and Cells
  *

--- a/api-docs/modern/modern/src/grid/filters/Plugin.js
+++ b/api-docs/modern/modern/src/grid/filters/Plugin.js
@@ -3,81 +3,81 @@
  * @since 6.7.0
  *
  * In general an gridfilters plugin will be passed to the grid:
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-grid
- *        fullscreen="true"
- *        itemConfig='{ "viewmodel": true }'
- *        plugins='{"gridfilters": true}'
- *        title='Filter Grid Demo'
- *        width="500"
- *        onready="plugin.onGridReady"
- *      >
- *        <ext-column dataIndex='firstname' text='First Name'></ext-column>
- *        <ext-column dataIndex='lastname' text='Last Name'></ext-column>
- *        <ext-column dataIndex='hired' text='Hired Month'></ext-column>
- *        <ext-column bind='{record.department} ({record.seniority})' text='Department' width="200"></ext-column>
- *      </ext-grid>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-grid
+ *  fullscreen="true"
+ *  itemConfig='{ "viewmodel": true }'
+ *  plugins='{"gridfilters": true}'
+ *  title='Filter Grid Demo'
+ *  width="500"
+ *  onready="plugin.onGridReady"
+ *>
+ *  <ext-column dataIndex='firstname' text='First Name'></ext-column>
+ *  <ext-column dataIndex='lastname' text='Last Name'></ext-column>
+ *  <ext-column dataIndex='hired' text='Hired Month'></ext-column>
+ *  <ext-column bind='{record.department} ({record.seniority})' text='Department' width="200"></ext-column>
+ *</ext-grid>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      export default class PluginComponent {
- *          constructor() {
- *              this.store=Ext.create('Ext.data.Store', {
- *                  fields: ['firstname', 'lastname', 'seniority', 'department', 'hired', 'active'],
- *                      data: [{
- *                          firstname:"Michael",
- *                          lastname:"Scott",
- *                          seniority:7,
- *                          department:"Management",
- *                          hired:"01/10/2004",
- *                          active: true
- *                     },
- *                     {
- *                          firstname:"Dwight",
- *                          lastname:"Schrute",
- *                          seniority:2,
- *                          department:"Sales",
- *                          hired:"04/01/2004",
- *                          active: true
- *                     },
- *                     {
- *                          firstname:"Jim",
- *                          lastname:"Halpert",
- *                          seniority:3,
- *                          department:"Sales",
- *                          hired:"02/22/2006",
- *                          active: false
- *                     },
- *                     {
- *                          firstname:"Kevin",
- *                          lastname:"Malone",
- *                          seniority:4,
- *                          department:"Accounting",
- *                          hired:"06/10/2007",
- *                          active: true
- *                     },
- *                     {
- *                          firstname:"Angela",
- *                          lastname:"Martin",
- *                          seniority:5,
- *                          department:"Accounting",
- *                          hired:"10/21/2008",
- *                          active: false
- *                     }
- *                 ]
- *             });
- *          }
+ *export default class PluginComponent {
+ *    constructor() {
+ *        this.store=Ext.create('Ext.data.Store', {
+ *            fields: ['firstname', 'lastname', 'seniority', 'department', 'hired', 'active'],
+ *                data: [{
+ *                    firstname:"Michael",
+ *                    lastname:"Scott",
+ *                    seniority:7,
+ *                    department:"Management",
+ *                    hired:"01/10/2004",
+ *                    active: true
+ *               },
+ *               {
+ *                    firstname:"Dwight",
+ *                    lastname:"Schrute",
+ *                    seniority:2,
+ *                    department:"Sales",
+ *                    hired:"04/01/2004",
+ *                    active: true
+ *               },
+ *               {
+ *                    firstname:"Jim",
+ *                    lastname:"Halpert",
+ *                    seniority:3,
+ *                    department:"Sales",
+ *                    hired:"02/22/2006",
+ *                    active: false
+ *               },
+ *               {
+ *                    firstname:"Kevin",
+ *                    lastname:"Malone",
+ *                    seniority:4,
+ *                    department:"Accounting",
+ *                    hired:"06/10/2007",
+ *                    active: true
+ *               },
+ *               {
+ *                    firstname:"Angela",
+ *                    lastname:"Martin",
+ *                    seniority:5,
+ *                    department:"Accounting",
+ *                    hired:"10/21/2008",
+ *                    active: false
+ *               }
+ *           ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.gridCmp = event.detail.cmp;
- *              this.gridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.gridCmp = event.detail.cmp;
+ *        this.gridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  *
  * # Convenience Subclasses
  *

--- a/api-docs/modern/modern/src/grid/plugin/CellEditing.js
+++ b/api-docs/modern/modern/src/grid/plugin/CellEditing.js
@@ -9,43 +9,43 @@
  * double-clicks on a cell in the column.  By default a `TextField` is used as the editor.  You
  * can substitute a different editor by adding a subclass of `Ext.field.Field` as a child of the `Column`.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid shadow="true" height="275" plugins='["cellediting"]' onready="editablegrid.onGridReady">
- *              <ext-column text="First Name" dataIndex="fname" flex="1" editable="true"></ext-column>
- *              <ext-column text="Last Name" dataIndex="lname" flex="1" editable="true"></ext-column>
- *              <ext-column text="Talent" dataIndex="talent" flex="1" editable="true"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid shadow="true" height="275" plugins='["cellediting"]' onready="editablegrid.onGridReady">
+ *        <ext-column text="First Name" dataIndex="fname" flex="1" editable="true"></ext-column>
+ *        <ext-column text="Last Name" dataIndex="lname" flex="1" editable="true"></ext-column>
+ *        <ext-column text="Talent" dataIndex="talent" flex="1" editable="true"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      Ext.require('Ext.grid.plugin.Editable');
+ *Ext.require('Ext.grid.plugin.Editable');
  *
- *      export default class EditableGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                data: [
- *                    { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
- *                    { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
- *                    { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
- *                    { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
- *                    { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
- *                ]
- *             });
- *          }
+ *export default class EditableGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          data: [
+ *              { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
+ *              { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
+ *              { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
+ *              { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
+ *              { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.editableGridCmp = event.detail.cmp;
- *              this.editableGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.editableGridCmp = event.detail.cmp;
+ *        this.editableGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/grid/plugin/Editable.js
+++ b/api-docs/modern/modern/src/grid/plugin/Editable.js
@@ -14,43 +14,43 @@
  * By default a `TextField` is used as the editor.  You can substitute a different editor by
  * adding a subclass of `Ext.field.Field` as a child of the `Column`.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid shadow="true" height="275" plugins='["cellediting"]' onready="editablegrid.onGridReady">
- *              <ext-column text="First Name" dataIndex="fname" flex="1" editable="true"></ext-column>
- *              <ext-column text="Last Name" dataIndex="lname" flex="1" editable="true"></ext-column>
- *              <ext-column text="Talent" dataIndex="talent" flex="1" editable="true"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid shadow="true" height="275" plugins='["cellediting"]' onready="editablegrid.onGridReady">
+ *        <ext-column text="First Name" dataIndex="fname" flex="1" editable="true"></ext-column>
+ *        <ext-column text="Last Name" dataIndex="lname" flex="1" editable="true"></ext-column>
+ *        <ext-column text="Talent" dataIndex="talent" flex="1" editable="true"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      Ext.require('Ext.grid.plugin.Editable');
+ *Ext.require('Ext.grid.plugin.Editable');
  *
- *      export default class EditableGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                data: [
- *                    { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
- *                    { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
- *                    { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
- *                    { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
- *                    { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
- *                ]
- *             });
- *          }
+ *export default class EditableGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          data: [
+ *              { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
+ *              { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
+ *              { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
+ *              { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
+ *              { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.editableGridCmp = event.detail.cmp;
- *              this.editableGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.editableGridCmp = event.detail.cmp;
+ *        this.editableGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/grid/plugin/PagingToolbar.js
+++ b/api-docs/modern/modern/src/grid/plugin/PagingToolbar.js
@@ -7,42 +7,42 @@
  * The Paging Toolbar is a specialized toolbar that is
  * bound to a `Ext.data.Store` and provides automatic paging control.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid shadow="true" height="275" plugins='["cellediting"]' onready="paginggrid.onGridReady">
- *              <ext-column text="First Name" dataIndex="fname" flex="1" editable="true"></ext-column>
- *              <ext-column text="Last Name" dataIndex="lname" flex="1" editable="true"></ext-column>
- *              <ext-column text="Talent" dataIndex="talent" flex="1" editable="true"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid shadow="true" height="275" plugins='["cellediting"]' onready="paginggrid.onGridReady">
+ *        <ext-column text="First Name" dataIndex="fname" flex="1" editable="true"></ext-column>
+ *        <ext-column text="Last Name" dataIndex="lname" flex="1" editable="true"></ext-column>
+ *        <ext-column text="Talent" dataIndex="talent" flex="1" editable="true"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      Ext.require('Ext.grid.plugin.PagingToolbar');
+ *Ext.require('Ext.grid.plugin.PagingToolbar');
  *
- *      export default class PagingGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                pageSize: 3,
- *                data: [
- *                    { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
- *                    { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
- *                    { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
- *                    { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
- *                    { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
- *                ]
- *             });
- *          }
+ *export default class PagingGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          pageSize: 3,
+ *          data: [
+ *              { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
+ *              { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
+ *              { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
+ *              { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
+ *              { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.pagingGridCmp = event.detail.cmp;
- *              this.pagingGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.pagingGridCmp = event.detail.cmp;
+ *        this.pagingGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  */

--- a/api-docs/modern/modern/src/grid/plugin/RowExpander.js
+++ b/api-docs/modern/modern/src/grid/plugin/RowExpander.js
@@ -6,59 +6,59 @@
  * The Row Expander plugin provides an "expander" column to give the user the ability to show
  * or hide the {@link Ext.grid.Row#cfg!body body} of each row.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid
- *            shadow="true"
- *            height="275"
- *            plugins='["rowexpander"]'
- *            onready="rowExpanderGrid.onGridReady"
- *            fullscreen="true"
- *            variableHeights="true"
- *          >
- *              <ext-column text="First Name" dataIndex="fname" flex="1"></ext-column>
- *              <ext-column text="Last Name" dataIndex="lname" flex="1"></ext-column>
- *              <ext-column text="Talent" dataIndex="talent" flex="1"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid
+ *      shadow="true"
+ *      height="275"
+ *      plugins='["rowexpander"]'
+ *      onready="rowExpanderGrid.onGridReady"
+ *      fullscreen="true"
+ *      variableHeights="true"
+ *    >
+ *        <ext-column text="First Name" dataIndex="fname" flex="1"></ext-column>
+ *        <ext-column text="Last Name" dataIndex="lname" flex="1"></ext-column>
+ *        <ext-column text="Talent" dataIndex="talent" flex="1"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      Ext.require('Ext.grid.plugin.RowExpander');
+ *Ext.require('Ext.grid.plugin.RowExpander');
  *
- *      export default class RowExpanderGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                sorters: [
- *                  { property: 'lname' }
- *                ],
- *                data: [
- *                    { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
- *                    { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
- *                    { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
- *                    { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
- *                    { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
- *                ]
- *             });
- *          }
+ *export default class RowExpanderGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          sorters: [
+ *            { property: 'lname' }
+ *          ],
+ *          data: [
+ *              { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster'},
+ *              { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery'},
+ *              { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All'},
+ *              { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert'},
+ *              { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower'  }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.rowExpanderGridCmp = event.detail.cmp;
- *              this.rowExpanderGridCmp.setItemConfig({ body: `
- *                  <div>
- *                      <img height="100" src="http://www.sencha.com/assets/images/sencha-avatar-64x64.png"/>
- *                      <div style="font-size: 16px; margin-bottom: 5px">{fname} {lname}</div>
- *                      <div style="font-weight: bold; font-size: 14px">{title}</div>
- *                      <div style="font-weight: bold">{department}</div>
- *                  </div>`
- *              });
- *              this.rowExpanderGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.rowExpanderGridCmp = event.detail.cmp;
+ *        this.rowExpanderGridCmp.setItemConfig({ body: `
+ *            <div>
+ *                <img height="100" src="http://www.sencha.com/assets/images/sencha-avatar-64x64.png"/>
+ *                <div style="font-size: 16px; margin-bottom: 5px">{fname} {lname}</div>
+ *                <div style="font-weight: bold; font-size: 14px">{title}</div>
+ *                <div style="font-weight: bold">{department}</div>
+ *            </div>`
+ *        });
+ *        this.rowExpanderGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  */

--- a/api-docs/modern/modern/src/grid/plugin/Summary.js
+++ b/api-docs/modern/modern/src/grid/plugin/Summary.js
@@ -28,51 +28,51 @@
  * + {@link Ext.data.summary.Min min}
  * + {@link Ext.data.summary.Sum sum}
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid
- *            shadow="true"
- *            height="275"
- *            plugins='["gridsummaryrow"]'
- *            onready="summaryGrid.onGridReady"
- *            fullscreen="true"
- *            variableHeights="true"
- *          >
- *              <ext-column text="First Name" dataIndex="fname" flex="1"></ext-column>
- *              <ext-column text="Last Name" dataIndex="lname" flex="1"></ext-column>
- *              <ext-column text="Talent" dataIndex="talent" flex="1"></ext-column>
- *              <ext-column text="Wins" dataIndex="wins" flex="1" summary="sum"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid
+ *      shadow="true"
+ *      height="275"
+ *      plugins='["gridsummaryrow"]'
+ *      onready="summaryGrid.onGridReady"
+ *      fullscreen="true"
+ *      variableHeights="true"
+ *    >
+ *        <ext-column text="First Name" dataIndex="fname" flex="1"></ext-column>
+ *        <ext-column text="Last Name" dataIndex="lname" flex="1"></ext-column>
+ *        <ext-column text="Talent" dataIndex="talent" flex="1"></ext-column>
+ *        <ext-column text="Wins" dataIndex="wins" flex="1" summary="sum"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      Ext.require('Ext.grid.plugin.Summary');
+ *Ext.require('Ext.grid.plugin.Summary');
  *
- *      export default class SummaryGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                data: [
- *                    { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster', 'wins': 150 },
- *                    { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery', 'wins': 120 },
- *                    { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All', 'wins': 90 },
- *                    { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert', 'wins': 70 },
- *                    { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower', 'wins': 60   }
- *                ]
- *             });
- *          }
+ *export default class SummaryGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          data: [
+ *              { 'fname': 'Barry',  'lname': 'Allen', 'talent': 'Speedster', 'wins': 150 },
+ *              { 'fname': 'Oliver', 'lname': 'Queen', 'talent': 'Archery', 'wins': 120 },
+ *              { 'fname': 'Kara',   'lname': 'Zor-El', 'talent': 'All', 'wins': 90 },
+ *              { 'fname': 'Helena', 'lname': 'Bertinelli', 'talent': 'Weapons Expert', 'wins': 70 },
+ *              { 'fname': 'Hal',    'lname': 'Jordan', 'talent': 'Willpower', 'wins': 60   }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.summaryGridCmp = event.detail.cmp;
- *              this.summaryGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.summaryGridCmp = event.detail.cmp;
+ *        this.summaryGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/grid/plugin/ViewOptions.js
+++ b/api-docs/modern/modern/src/grid/plugin/ViewOptions.js
@@ -12,42 +12,42 @@
  * Once the columns are ordered to your liking, you may then close the menu by tapping the
  * "Done" button.
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="100%" height="100%">
- *          <ext-grid shadow="true" height="100%" onready="basicgrid.onGridReady" plugins='["gridviewoptions"]'>
- *              <ext-column text="Name" dataIndex="name" flex="1" sortable="false"></ext-column>
- *              <ext-column text="Email" dataIndex="email" flex="1"></ext-column>
- *              <ext-column text="Phone" dataIndex="phone" flex="1"></ext-column>
- *          </ext-grid>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-grid.component';
- *      import '@sencha/ext-web-components/dist/ext-column.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="100%" height="100%">
+ *    <ext-grid shadow="true" height="100%" onready="basicgrid.onGridReady" plugins='["gridviewoptions"]'>
+ *        <ext-column text="Name" dataIndex="name" flex="1" sortable="false"></ext-column>
+ *        <ext-column text="Email" dataIndex="email" flex="1"></ext-column>
+ *        <ext-column text="Phone" dataIndex="phone" flex="1"></ext-column>
+ *    </ext-grid>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-grid.component';
+ *import '@sencha/ext-web-components/dist/ext-column.component';
  *
- *      Ext.require('Ext.grid.plugin.ViewOptions');
+ *Ext.require('Ext.grid.plugin.ViewOptions');
  *
- *      export default class BasicGridComponent {
- *          constructor() {
- *             this.store = new Ext.data.Store({
- *                data: [
- *                    { "name": "Lisa", "email": "lisa@simpsons.com", "phone": "555-111-1224" },
- *                    { "name": "Bart", "email": "bart@simpsons.com", "phone": "555-222-1234" },
- *                    { "name": "Homer", "email": "home@simpsons.com", "phone": "555-222-1244" },
- *                    { "name": "Marge", "email": "marge@simpsons.com", "phone": "555-222-1254" }
- *                ]
- *             });
- *          }
+ *export default class BasicGridComponent {
+ *    constructor() {
+ *       this.store = new Ext.data.Store({
+ *          data: [
+ *              { "name": "Lisa", "email": "lisa@simpsons.com", "phone": "555-111-1224" },
+ *              { "name": "Bart", "email": "bart@simpsons.com", "phone": "555-222-1234" },
+ *              { "name": "Homer", "email": "home@simpsons.com", "phone": "555-222-1244" },
+ *              { "name": "Marge", "email": "marge@simpsons.com", "phone": "555-222-1254" }
+ *          ]
+ *       });
+ *    }
  *
- *          onGridReady(event) {
- *              this.basicGridCmp = event.detail.cmp;
- *              this.basicGridCmp.setStore(this.store);
- *          }
- *      }
- *      ```
+ *    onGridReady(event) {
+ *        this.basicGridCmp = event.detail.cmp;
+ *        this.basicGridCmp.setStore(this.store);
+ *    }
+ *}
+ *```
  *
  * Developers may modify the menu and its contents by overriding {@link #sheet} and
  * {@link #columnList} respectively.

--- a/api-docs/modern/modern/src/layout/Fit.js
+++ b/api-docs/modern/modern/src/layout/Fit.js
@@ -10,20 +10,20 @@
  * panel to a container using Fit layout, simply set `layout: 'fit'` on the container and
  * add a single panel to it.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container width="300" height="150" layout="fit">
- *          <ext-panel title="Inner Panel" bodyPadding="20" border="false">
- *               This is the inner panel content
- *          </ext-panel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container width="300" height="150" layout="fit">
+ *    <ext-panel title="Inner Panel" bodyPadding="20" border="false">
+ *         This is the inner panel content
+ *    </ext-panel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-spinnerfield.component';
  * 
- *      export default class FitComponent {}
- *      ```
+ *export default class FitComponent {}
+ *```
  */

--- a/api-docs/modern/modern/src/layout/Form.js
+++ b/api-docs/modern/modern/src/layout/Form.js
@@ -10,23 +10,23 @@
  * The following example uses label-auto-widthing to size all labels to the width of the
  * largest label.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-formpanel title="Form Panel">
- *          <ext-textfield label="First Name"/>
- *          <ext-textfield label="Last Name"/>
- *          <ext-textfield label="Account Number"/>
- *          <ext-button text="Submit">
- *      </ext-formpanel>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-button.component';
- *      import '@sencha/ext-web-components/dist/ext-formpanel.component';
- *      import '@sencha/ext-web-components/dist/ext-textfield.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-formpanel title="Form Panel">
+ *    <ext-textfield label="First Name"/>
+ *    <ext-textfield label="Last Name"/>
+ *    <ext-textfield label="Account Number"/>
+ *    <ext-button text="Submit">
+ *</ext-formpanel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-formpanel.component';
+ *import '@sencha/ext-web-components/dist/ext-textfield.component';
  * 
- *      export default class FormComponent {}
- *      ```
+ *export default class FormComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/layout/HBox.js
+++ b/api-docs/modern/modern/src/layout/HBox.js
@@ -10,24 +10,24 @@
  * For example, an email client might have a list of messages pinned to the left, taking say one third of the available
  * width, and a message viewing panel in the rest of the screen. We can achieve this with hbox layout's *flex* config:
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="hbox">
- *          <ext-panel title="Inner Panel 1" flex="1">
- *              This is the inner panel content
- *          </ext-panel>
- *          <ext-panel title="Inner Panel 2" flex="1">
- *              This is the inner panel content
- *          </ext-panel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="hbox">
+ *    <ext-panel title="Inner Panel 1" flex="1">
+ *        This is the inner panel content
+ *    </ext-panel>
+ *    <ext-panel title="Inner Panel 2" flex="1">
+ *        This is the inner panel content
+ *    </ext-panel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
  * 
- *      export default class HBoxComponent {}
- *      ```
+ *export default class HBoxComponent {}
+ *```
  *
  * This will give us two boxes - one that's one third of the available width, the other being two thirds of the
  * available width.
@@ -35,25 +35,25 @@
  * We can also specify fixed widths for child items, or mix fixed widths and flexes. For example, here we have 3 items
  * - one on each side with flex: 1, and one in the center with a fixed width of 100px:
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="hbox">
- *          <ext-panel title="Inner Panel 1" flex="1">
- *              This is the inner panel content
- *          </ext-panel>
- *          <ext-panel title="Inner Panel 2" width="100">
- *              This is the inner panel content
- *          </ext-panel>
- *          <ext-panel title="Inner Panel 3" flex="1">
- *              This is the inner panel content
- *          </ext-panel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="hbox">
+ *    <ext-panel title="Inner Panel 1" flex="1">
+ *        This is the inner panel content
+ *    </ext-panel>
+ *    <ext-panel title="Inner Panel 2" width="100">
+ *        This is the inner panel content
+ *    </ext-panel>
+ *    <ext-panel title="Inner Panel 3" flex="1">
+ *        This is the inner panel content
+ *    </ext-panel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
  * 
- *      export default class myExample extends Component {}
- *      ```
+ *export default class myExample extends Component {}
+ *```
  */

--- a/api-docs/modern/modern/src/layout/VBox.js
+++ b/api-docs/modern/modern/src/layout/VBox.js
@@ -11,24 +11,24 @@
  * an information panel in the rest of the screen. We can achieve this with vbox layout's
  * *flex* config:
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="vbox">
- *          <ext-panel title="Inner Panel 1" flex="1">
- *               This is the inner panel content
- *          </ext-panel>
- *          <ext-panel title="Inner Panel 2" flex="1">
- *               This is the inner panel content
- *          </ext-panel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="vbox">
+ *    <ext-panel title="Inner Panel 1" flex="1">
+ *         This is the inner panel content
+ *    </ext-panel>
+ *    <ext-panel title="Inner Panel 2" flex="1">
+ *         This is the inner panel content
+ *    </ext-panel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
  * 
- *      export default class VBoxComponent {}
- *      ```
+ *export default class VBoxComponent {}
+ *```
  *
  * This will give us two boxes - one that's one third of the available height, the other
  * being two thirds of the available height.
@@ -37,25 +37,25 @@
  * example, here we have 3 items - one at the top and bottom with flex: 1, and one in the
  * center with a fixed width of 100px:
  *
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container layout="vbox">
- *          <ext-panel title="Inner Panel 1" flex="1">
- *               This is the inner panel content
- *          </ext-panel>
- *          <ext-panel title="Inner Panel 2" height="100">
- *               This is the inner panel content
- *          </ext-panel>
- *          <ext-panel title="Inner Panel 3" flex="1">
- *               This is the inner panel content
- *          </ext-panel>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-panel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container layout="vbox">
+ *    <ext-panel title="Inner Panel 1" flex="1">
+ *         This is the inner panel content
+ *    </ext-panel>
+ *    <ext-panel title="Inner Panel 2" height="100">
+ *         This is the inner panel content
+ *    </ext-panel>
+ *    <ext-panel title="Inner Panel 3" flex="1">
+ *         This is the inner panel content
+ *    </ext-panel>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-panel.component';
  * 
- *      export default class myExample extends Component {}
- *      ```
+ *export default class myExample extends Component {}
+ *```
  */

--- a/api-docs/modern/modern/src/menu/CheckItem.js
+++ b/api-docs/modern/modern/src/menu/CheckItem.js
@@ -5,26 +5,26 @@
  *
  * A menu item that contains a togglable checkbox by default, but that can also be a part of a radio group.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-button text="Menu">
- *              <ext-menu rel="menu" >
- *                  <ext-menucheckitem text="Mobile" name="ui-type" />
- *                  <ext-menucheckitem text="Desktop" name="ui-type"/>
- *              </ext-menu>
- *          </ext-button>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
- *      import '@sencha/ext-web-components/dist/ext-menu.component';
- *      import '@sencha/ext-web-components/dist/ext-menucheckitem.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-button text="Menu">
+ *        <ext-menu rel="menu" >
+ *            <ext-menucheckitem text="Mobile" name="ui-type" />
+ *            <ext-menucheckitem text="Desktop" name="ui-type"/>
+ *        </ext-menu>
+ *    </ext-button>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-menu.component';
+ *import '@sencha/ext-web-components/dist/ext-menucheckitem.component';
  * 
- *      export default class CheckItemComponent {}
- *      ```
+ *export default class CheckItemComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/menu/Item.js
+++ b/api-docs/modern/modern/src/menu/Item.js
@@ -5,26 +5,26 @@
  *
  * A base class for all menu items that require menu-related functionality such as click handling,
  * sub-menus, icons, etc.
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-button text="Menu">
- *              <ext-menu rel="menu" >
- *                  <ext-menuitem text="Mobile" name="ui-type" />
- *                  <ext-menuitem text="Desktop" name="ui-type"/>
- *              </ext-menu>
- *          </ext-button>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
- *      import '@sencha/ext-web-components/dist/ext-menu.component';
- *      import '@sencha/ext-web-components/dist/ext-menuitem.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-button text="Menu">
+ *        <ext-menu rel="menu" >
+ *            <ext-menuitem text="Mobile" name="ui-type" />
+ *            <ext-menuitem text="Desktop" name="ui-type"/>
+ *        </ext-menu>
+ *    </ext-button>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-menu.component';
+ *import '@sencha/ext-web-components/dist/ext-menuitem.component';
  * 
- *      export default class ItemComponent{}
- *      ```
+ *export default class ItemComponent{}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/menu/Menu.js
+++ b/api-docs/modern/modern/src/menu/Menu.js
@@ -16,26 +16,26 @@
  * Menu with `{@link #cfg-floated}: false`, a Menu may be used as a child of a 
  * {@link Ext.Container Container}.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-button text="Menu">
- *              <ext-menu rel="menu" >
- *                  <ext-menuitem text="Mobile" name="ui-type" />
- *                  <ext-menuitem text="Desktop" name="ui-type"/>
- *              </ext-menu>
- *          </ext-button>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
- *      import '@sencha/ext-web-components/dist/ext-menu.component';
- *      import '@sencha/ext-web-components/dist/ext-menuitem.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-button text="Menu">
+ *        <ext-menu rel="menu" >
+ *            <ext-menuitem text="Mobile" name="ui-type" />
+ *            <ext-menuitem text="Desktop" name="ui-type"/>
+ *        </ext-menu>
+ *    </ext-button>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-menu.component';
+ *import '@sencha/ext-web-components/dist/ext-menuitem.component';
  * 
- *      export default class MenuComponent {}
- *      ```
+ *export default class MenuComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/menu/RadioItem.js
+++ b/api-docs/modern/modern/src/menu/RadioItem.js
@@ -6,26 +6,26 @@
  * A menu item that contains a radio button item which can participate in a group of
  * mutually exclusive radio items.
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-button text="Menu">
- *              <ext-menu rel="menu" >
- *                  <ext-menuradioitem text="Mobile" name="ui-type" />
- *                  <ext-menuradioitem text="Desktop" name="ui-type"/>
- *              </ext-menu>
- *          </ext-button>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-button.component';
- *      import '@sencha/ext-web-components/dist/ext-menu.component';
- *      import '@sencha/ext-web-components/dist/ext-menuradioitem.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container>
+ *    <ext-button text="Menu">
+ *        <ext-menu rel="menu" >
+ *            <ext-menuradioitem text="Mobile" name="ui-type" />
+ *            <ext-menuradioitem text="Desktop" name="ui-type"/>
+ *        </ext-menu>
+ *    </ext-button>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-menu.component';
+ *import '@sencha/ext-web-components/dist/ext-menuradioitem.component';
  * 
- *      export default class RadioItemComponent {}
- *      ```
+ *export default class RadioItemComponent {}
+ *```
  */
 
 /**

--- a/api-docs/modern/modern/src/panel/Time.js
+++ b/api-docs/modern/modern/src/panel/Time.js
@@ -10,17 +10,17 @@
  *
  * Example usage:
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-container padding={10} layout='{"auto"}'>
- *          <ext-timepanel shadow/>
- *      </ext-container>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-timepanel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-container padding={10} layout='{"auto"}'>
+ *    <ext-timepanel shadow/>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-timepanel.component';
  * 
- *      export default class TimeComponent {}
- *      ```
+ *export default class TimeComponent {}
+ *```
  */

--- a/api-docs/modern/modern/src/picker/Date.js
+++ b/api-docs/modern/modern/src/picker/Date.js
@@ -9,33 +9,33 @@
  * This component has no required configurations.
  *
  * ## Examples
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-button ui="action" ontap="datepicker.showPicker" text="Show Picker"></ext-button>
- *          <ext-datepicker
- *              onready="date.datepickerReady"
- *          >
- *          </ext-datepicker>     
- *      </ext-container>
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
+ *```HTML
+ * @example({tab: 1})
+ * <ext-container>
+ *     <ext-button ui="action" ontap="datepicker.showPicker" text="Show Picker"></ext-button>
+ *     <ext-datepicker
+ *         onready="date.datepickerReady"
+ *     >
+ *     </ext-datepicker>     
+ * </ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
  *
- *     import '@sencha/ext-web-components/dist/ext-container.component';
- *     import '@sencha/ext-web-components/dist/ext-datepicker.component';
- *     import '@sencha/ext-web-components/dist/ext-button.component'; 
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-datepicker.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component'; 
  * 
- *     export default class DatePickerComponent {
- *          datepickerReady = (event) => {
- *              this.pickerCmp = event.detail.cmp;
- *          }
- * 
- *          showPicker = () => {
- *              this.pickerCmp.show();
- *          }
+ *export default class DatePickerComponent {
+ *     datepickerReady = (event) => {
+ *         this.pickerCmp = event.detail.cmp;
  *     }
- *     ```
+ * 
+ *     showPicker = () => {
+ *         this.pickerCmp.show();
+ *     }
+ *}
+ *```
  */
 /**
  * @event change

--- a/api-docs/modern/modern/src/picker/Picker.js
+++ b/api-docs/modern/modern/src/picker/Picker.js
@@ -13,43 +13,43 @@
  * - `data`/`store`: The data or store to use for this slot.
  *
  * ## Example
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-container>
- *          <ext-button ui="action" ontap="picker.showPicker" text="Show Picker"></ext-button>
- *              <ext-picker
- *                  onready="picker.pickerReady"
- *                  slots='[{
- *                          "name": "limit_speed",
- *                          "title": "Speed",
- *                          "data": [
- *                                      {"text": "50 KB/s", "value": "50"},
- *                                      {"text": "100 KB/s", "value": "100"},
- *                                      {"text": "200 KB/s", "value": "200"},
- *                                      {"text": "300 KB/s", "value": "300"}
- *                                  ]                              
- *                      }]'
- *             >
- *      </ext-picker>
- *    </ext-container>
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
+ *```HTML
+ * @example({tab: 1})
+ * <ext-container>
+ *     <ext-button ui="action" ontap="picker.showPicker" text="Show Picker"></ext-button>
+ *     <ext-picker
+ *         onready="picker.pickerReady"
+ *             slots='[{
+ *                     "name": "limit_speed",
+ *                     "title": "Speed",
+ *                     "data": [
+ *                                 {"text": "50 KB/s", "value": "50"},
+ *                                 {"text": "100 KB/s", "value": "100"},
+ *                                 {"text": "200 KB/s", "value": "200"},
+ *                                 {"text": "300 KB/s", "value": "300"}
+ *                             ]                              
+ *                     }]'
+ *      >
+ *    </ext-picker>
+ *</ext-container>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
  *
- *     import '@sencha/ext-web-components/dist/ext-container.component';
- *     import '@sencha/ext-web-components/dist/ext-button.component';
- *     import '@sencha/ext-web-components/dist/ext-picker.component';
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-button.component';
+ *import '@sencha/ext-web-components/dist/ext-picker.component';
  * 
- *     export default class PickerComponent {
- *          pickerReady = (event) => {
- *              this.pickerCmp = event.detail.cmp;
- *          }
- * 
- *          showPicker = () => {
- *               this.pickerCmp.show();
- *          }
+ *export default class PickerComponent {
+ *     pickerReady = (event) => {
+ *         this.pickerCmp = event.detail.cmp;
  *     }
- *     ```
+ * 
+ *     showPicker = () => {
+ *          this.pickerCmp.show();
+ *     }
+ *}
+ *```
  */
 /**
  * @event pick

--- a/api-docs/modern/modern/src/tab/Panel.js
+++ b/api-docs/modern/modern/src/tab/Panel.js
@@ -8,27 +8,27 @@
  * the top or the bottom of the Tab Panel, and can optionally accept title and icon
  * configurations (see {@link Ext.Button#iconCls iconCls} for additional information).
  * 
- *      ```HTML
- *      @example({tab: 1})
- *      <ext-tabpanel>
- *          <ext-container title="Tab 1">
- *               This is content for Tab 1!
- *          </ext-container>
- *          <ext-container title="Tab 2">
- *               This is content for Tab 2!
- *          </ext-container>
- *          <ext-container title="Tab 3">
- *               This is content for Tab 3!
- *          </ext-container>
- *      </ext-tabpanel>
- *      ```
- *      ```javascript
- *      @example({tab: 2, packages: ['ext-web-components']})
- *      import '@sencha/ext-web-components/dist/ext-container.component';
- *      import '@sencha/ext-web-components/dist/ext-tabpanel.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-tabpanel>
+ *    <ext-container title="Tab 1">
+ *         This is content for Tab 1!
+ *    </ext-container>
+ *    <ext-container title="Tab 2">
+ *         This is content for Tab 2!
+ *    </ext-container>
+ *    <ext-container title="Tab 3">
+ *         This is content for Tab 3!
+ *    </ext-container>
+ *</ext-tabpanel>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-container.component';
+ *import '@sencha/ext-web-components/dist/ext-tabpanel.component';
  * 
- *      export default class PanelComponent {}
- *      ```
+ *export default class PanelComponent {}
+ *```
  * 
  * One tab was created for each of the {@link Ext.Container containers} defined in the within the tabpanel.
  * Each tab automatically uses the title and icon defined on the item configuration, and

--- a/api-docs/ux/modern/src/colorpick/Button.js
+++ b/api-docs/ux/modern/src/colorpick/Button.js
@@ -3,26 +3,26 @@
  *
  * The selected color is configurable via {@link #value} and
  * The Format is configurable via {@link #format}.
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-colorbutton
- *         onchange="button.showMessage"
- *         format="hex6"
- *         value="00f"
- *      >
- *     </ext-colorbutton>
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
- *     import '@sencha/ext-web-components/dist/ext-colorbutton.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-colorbutton
+ *    onchange="button.showMessage"
+ *    format="hex6"
+ *    value="00f"
+ *>
+ *</ext-colorbutton>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-colorbutton.component';
  * 
- *     export default class ButtonComponent {
- *      showMessage = (event) => {
- *          const color = event.detail.color;
- *          Ext.Msg.alert('Color', color);
- *       }
- *     }
- *     ```
+ *export default class ButtonComponent {
+ * showMessage = (event) => {
+ *     const color = event.detail.color;
+ *     Ext.Msg.alert('Color', color);
+ *  }
+ *}
+ *```
  */
 
 /**

--- a/api-docs/ux/modern/src/colorpick/Field.js
+++ b/api-docs/ux/modern/src/colorpick/Field.js
@@ -2,27 +2,26 @@
  * A field that can be clicked to bring up the color picker.
  * The selected color is configurable via {@link #value} and
  * The Format is configurable via {@link #format}.
- *  HTML
- *     ```HTML
- *      @example({tab: 1})
- *      <ext-colorfield
- *         onchange="field.showMessage"
- *         format="hex6"
- *         value="00f"
- *      >
- *      </ext-colorfield>
- *     ```
- *       JS
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
- *     import '@sencha/ext-web-components/dist/ext-colorfield.component';
+ *
+ *```HTML
+ *@example({tab: 1})
+ *<ext-colorfield
+ *   onchange="field.showMessage"
+ *   format="hex6"
+ *   value="00f"
+ *>
+ *</ext-colorfield>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-colorfield.component';
  * 
- *     export default class FieldComponent {
- *       showMessage = (event) => {
- *          Ext.Msg.alert('Color', event.detail.color);
- *       }
- *     }
- *     ```
+ *export default class FieldComponent {
+ *  showMessage = (event) => {
+ *     Ext.Msg.alert('Color', event.detail.color);
+ *  }
+ *}
+ *```
  */
 
  /**

--- a/api-docs/ux/modern/src/colorpick/Selector.js
+++ b/api-docs/ux/modern/src/colorpick/Selector.js
@@ -6,26 +6,26 @@
  * The default selected color is configurable via {@link #value} prop
  * and The Format is configurable via {@link #format}. Usually used in
  * forms via {@link Ext.ux.colorpick.Button} or {@link Ext.ux.colorpick.Field}.
- *     ```HTML
- *      @example({tab: 1})
- *     <ext-colorselector
- *         onchange="selector.showMessage"
- *         format="hex6"
- *         value="00f"
- *      >
- *     </ext-colorselector>
- *     ```
- *     ```javascript
- *     @example({tab: 2, packages: ['ext-web-components']})
- *     import '@sencha/ext-web-components/dist/ext-colorselector.component';
+ *```HTML
+ *@example({tab: 1})
+ *<ext-colorselector
+ *    onchange="selector.showMessage"
+ *    format="hex6"
+ *    value="00f"
+ *>
+ *</ext-colorselector>
+ *```
+ *```javascript
+ *@example({tab: 2, packages: ['ext-web-components']})
+ *import '@sencha/ext-web-components/dist/ext-colorselector.component';
  * 
- *     export default class SelectorComponent {
- *       showMessage = (event) => {
- *          const color = event.detail.color;
- *          Ext.Msg.alert('Color', color);
- *       }
- *     }
- *     ```
+ *export default class SelectorComponent {
+ *  showMessage = (event) => {
+ *     const color = event.detail.color;
+ *     Ext.Msg.alert('Color', color);
+ *  }
+ *}
+ *```
  * 
  */
 


### PR DESCRIPTION
This PR is focussed over ApiDocs minor update . Fiddle examples of following components are updated where extra spaces in docs are removed under this PR:
1. Container
2. Progress
3. Tree
4. ActionSheet
5. Img
6. MessageBox
7. Panel
8. SegmentedButton
9. SplitButton
10. TitleBar
11. Toast
12. Toolbar
13. Carousel
14. DataView
15. Text
16. TextArea
17. Toggle
18. Url
19. FieldSet
20. Panel
21. Grid
22. Plugin
23. CellEditing
24. Editable
25. PagingToolbar
26. RowExpander
27. Summary
28. ViewOptions
29. Fit
30. Form
31. HBox
32. VBox
33. CheckItem
34. Item
35. Menu
36. RadioItem
37. Time
38. Date
39. Picker
40. Panel
41. Button
42. Selector
43. IndexBar
44. List
45. NestedList
46. Dialog
47. Checkbox
48. ComboBox
49. Button
50. Spinner
51. Date
52. Email
53. File
54. Hidden
55. Number
56. Password
57. Radio
58. Search
59. Select
60. Slider
61. Text