### PR TITLE
EWC-4 | EWC-28572 | Code icon is rectified for IE 11

### DIFF
--- a/packages/ext-web-components-kitchensink/src/view/main/MainComponent.html
+++ b/packages/ext-web-components-kitchensink/src/view/main/MainComponent.html
@@ -19,14 +19,18 @@
         height="100%"
     >
     </ext-breadcrumbbar>
-    <ext-button weight="5" hidden=true onready="main.readyCodeButton"
-        ui="fab"
-        iconCls="x-font-icon md-icon-code"
-        right="15"
-        zIndex="10000"
-        ontap="main.toggleCode"
-      >
-      </ext-button>
+    <ext-button
+      weight="5"
+      hidden="true"
+      onready="main.readyCodeButton"
+      ui="fab"
+      right="15"
+      top="-4"
+      text="<>"
+      zIndex="10000"
+      ontap="main.toggleCode"
+    >
+    </ext-button>
   </ext-toolbar>
   <!-- Navtree starts-->
   <ext-panel


### PR DESCRIPTION
In this PR, A bug found by QE is resolved related to the code icon for IE 11 is now fixed as per the ticket EWC-28572.

Kindly Review
Medha Singh