### PR TITLE
EWC-29 For IE Core JS CDN is used.

### DIFF
--- a/packages/ext-web-components-kitchensink/src/index.html
+++ b/packages/ext-web-components-kitchensink/src/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes">
   <title>ExtWebComponents 7.1 Kitchen Sink</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/2.6.11/core.min.js"></script>
   <script src="webcomponents-bundle.js"></script>
   <script src="resources/code.js"></script>
   <link rel="icon" type="image/x-icon" href="resources/favicon.ico">


### PR DESCRIPTION
In this PR, Core-JS polyfill is appended inside the head of the html to make the KS application work on IE-11

Kindly Review
Rahul Garg